### PR TITLE
Fix: Duplicate keys and add more ignored items plus other changes

### DIFF
--- a/constants/DisabledFeatures.json
+++ b/constants/DisabledFeatures.json
@@ -1,4 +1,4 @@
 {
-  "mushroom_cow_nether_warts": false,
-  "user_api_keys": false
+  "features": {
+  }
 }

--- a/constants/Garden.json
+++ b/constants/Garden.json
@@ -811,18 +811,18 @@
       ]
     },
     "Royal Resident": {
+      "rarity": "uncommon",
+      "need_items": []
+    },
+    "Royal Resident 2": {
+      "rarity": "uncommon",
+      "need_items": []
+    },
+    "Royal Resident 3": {
       "rarity": "rare",
       "need_items": [
         "Wheat"
       ]
-    },
-    "Royal Resident": {
-      "rarity": "uncommon",
-      "need_items": []
-    },
-    "Royal Resident": {
-      "rarity": "uncommon",
-      "need_items": []
     },
     "Rusty": {
       "rarity": "rare",

--- a/constants/HideNotClickableItems.json
+++ b/constants/HideNotClickableItems.json
@@ -80,6 +80,41 @@
       "New Year Cake Bag"
     ]
   },
+  "hide_player_trade": {
+    "equals": [
+      "Builder's Wand"
+    ],
+    "startsWith": [],
+    "endsWith": [
+      "Cat Talisman",
+      "Cheetah Talisman",
+      "Day Crystal",
+      "Lynx Talisman",
+      "Night Crystal"
+    ],
+    "contains": [
+      "Personal Deletor "
+    ]
+  },
+  "not_auctionable": {
+    "equals": [
+      "Basket of Seeds",
+      "InfiniDirt™ Wand",
+      "Nether Wart Pouch",
+      "Prismapump"
+    ],
+    "startsWith": [],
+    "endsWith": [
+      "Day Crystal",
+      "Cat Talisman",
+      "Cheetah Talisman",
+      "Lynx Talisman",
+      "Night Crystal"
+    ],
+    "contains": [
+      "Personal Deletor "
+    ]
+  },
   "salvage": {
     "armor": [
       "Bouncy",
@@ -116,46 +151,5 @@
       "Zombie Knight Sword",
       "Zombie Soldier Cutlass"
     ]
-  },
-  "hide_player_trade": {
-    "equals": [
-      "Builder's Wand"
-    ],
-    "startsWith": [],
-    "endsWith": [
-      "Cat Talisman",
-      "Cheetah Talisman",
-      "Day Crystal",
-      "Lynx Talisman",
-      "Night Crystal"
-    ],
-    "contains": [
-      "Personal Deletor "
-    ]
-  },
-  "not_auctionable": {
-    "equals": [
-      "Basket of Seeds",
-      "InfiniDirt™ Wand",
-      "Nether Wart Pouch",
-      "Prismapump"
-    ],
-    "startsWith": [],
-    "endsWith": [
-      "Day Crystal",
-      "Cat Talisman",
-      "Cheetah Talisman",
-      "Lynx Talisman",
-      "Night Crystal"
-    ],
-    "contains": [
-      "Personal Deletor "
-    ]
-  },
-  "demo": {
-    "equals": [],
-    "startsWith": [],
-    "endsWith": [],
-    "contains": []
   }
 }

--- a/constants/IgnoredItems.json
+++ b/constants/IgnoredItems.json
@@ -1,5 +1,5 @@
 {
-  "exact": [
+  "equals": [
     "MONSTER_EGG-120",
     "STEP-8",
     "STEP-11",

--- a/constants/IgnoredItems.json
+++ b/constants/IgnoredItems.json
@@ -1,6 +1,8 @@
 {
   "equals": [
+    "LEAVES_2-2",
     "MONSTER_EGG-120",
+    "PRISMARINE-7",
     "STEP-8",
     "STEP-11",
     "STEP-13",
@@ -12,6 +14,7 @@
     "SAND-9",
     "STONE-9",
     "WOOD_STEP-7",
+    "WOOD_STEP-10",
     "WOOD_STEP-11",
     "WOOD_STEP-13",
     "RED_ROSE-9",
@@ -20,15 +23,15 @@
   ],
   "contains": [
     "BOW-",
-    "LEATHER_BOOTS-",
-    "MAP-",
-    "LOG_2-",
     "DIRT-",
     "FISHING_ROD-",
-    "SKULL_ITEM-",
-    "OBSIDIAN-",
     "HAY_BLOCK-",
-    "YELLOW_FLOWER-",
-    "SPONGE-"
+    "LEATHER_BOOTS-",
+    "LOG_2-",
+    "MAP-",
+    "OBSIDIAN-",
+    "SKULL_ITEM-",
+    "SPONGE-",
+    "YELLOW_FLOWER-"
   ]
 }

--- a/constants/PlayerChatFilter.json
+++ b/constants/PlayerChatFilter.json
@@ -3,46 +3,32 @@
     {
       "description": "Player is advertising their lowballing",
       "contains": [
-        "lowballing",
-        "lowbal",
-        "lowwbal",
-        "lo-ballin"
+        "low balling",
+        "lowbal"
       ],
       "containsWord": [
-        "low balling",
-        "loballing"
-      ]
-    },
-    {
-      "description": "Player is looking for a lowballer",
-      "contains": [
-        "lowballer"
+        "lowwbal",
+        "lo-ballin",
+        "loballin",
+        "lowblling"
       ]
     },
     {
       "description": "Player wants to buy stuff",
-      "containsWord": [
-        "buying",
+      "contains": [
         "i buy",
-        "someone sells"
+        "someone sells",
+        "buying"
       ]
     },
     {
       "description": "Player wants to sell stuff",
       "contains": [
-        "check my ah",
         "my ah",
+        "my auction",
         "on ah",
         "selling",
-        "pls buy my",
-        "on my ah"
-      ],
-      "containsWord": [
-        "sell",
-        "sellng",
-        "sellomg",
-        "seling",
-        "my ahh",
+        "buy my",
         "low price",
         "bid on",
         "to buy",
@@ -50,26 +36,31 @@
         "i buy",
         "check out my auction",
         "on /ah",
-        "buy quickly for",
-        "buy my auction"
+        "buy quickly for"
+      ],
+      "containsWord": [
+        "sell",
+        "sellng",
+        "sellomg",
+        "seling"
       ]
     },
     {
       "description": "Player wants to advertise a minion shop",
-      "containsWord": [
+      "contains": [
         "minion shop",
         "minion store"
       ]
     },
     {
       "description": "Player wants to quit skyblock",
-      "containsWord": [
+      "contains": [
         "quitting skyblock"
       ]
     },
     {
       "description": "Player wants to apply reforge stone",
-      "containsWord": [
+      "contains": [
         "applying reforges",
         "mining 30 to apply",
         "apply spiritual to"
@@ -77,7 +68,7 @@
     },
     {
       "description": "Player wants to sell building island farms",
-      "containsWord": [
+      "contains": [
         "building your farms",
         "building farms"
       ]
@@ -85,9 +76,7 @@
     {
       "description": "Player asks for free stuff",
       "contains": [
-        "at map"
-      ],
-      "containsWord": [
+        "at map",
         "upgrade my",
         "fund me",
         "donate me",
@@ -95,6 +84,25 @@
         "got scammed",
         "dirt to hyp",
         "give me plz"
+      ]
+    },
+    {
+      "description": "Player asks for free stuff",
+      "contains": [
+        "at map",
+        "upgrade my",
+        "fund me",
+        "donate me",
+        "can someone give me",
+        "got scammed",
+        "dirt to hyp",
+        "give me plz"
+      ]
+    },
+    {
+      "description": "Player want you to visit them",
+      "contains": [
+        "visit me"
       ]
     }
   ]

--- a/constants/QuickCraftableItems.json
+++ b/constants/QuickCraftableItems.json
@@ -142,6 +142,7 @@
   "Rough Ruby Gemstone",
   "Rough Sapphire Gemstone",
   "Rough Topaz Gemstone",
+  "Silver Magmafish",
   "Sugar",
   "Sugar Cane",
   "Super Enchanted Egg",


### PR DESCRIPTION
- Will not break the mod for anyone (mod assumes uncommon visitor for all 3 regardless of rarity)
- Will be needed for [my pr soon which improves repo errors](https://github.com/hannibal002/SkyHanni/pull/605)
- If someone wants to they can work out which visitor is which and then get the correct data (my pr will not do this)
- Change exact to equals in ignored items (will not affect anyone)
- Add more ignored items and order them alphabetically
- Improve chat filters (recategorise stuff, add more filters, remove unneeded ones)
- remove demo from hide not clickable items json and move salvage info to the bottom
- update disabled features format (wont break anyone on old versions)
- Add silver magma fish to quick craftable items