### PR TITLE
Remove Sugar from quick craftable items

### DIFF
--- a/constants/QuickCraftableItems.json
+++ b/constants/QuickCraftableItems.json
@@ -143,7 +143,6 @@
   "Rough Sapphire Gemstone",
   "Rough Topaz Gemstone",
   "Silver Magmafish",
-  "Sugar",
   "Sugar Cane",
   "Super Enchanted Egg",
   "Wheat",


### PR DESCRIPTION
Sugar is not a proper compact form of sugar cane, and cannot be turned into sugar cane or enchanted sugar. It often shows up when trying to craft sugar cane into enchanted sugar.