### PR TITLE
added extendedBurningDesertSlayerArea

### DIFF
--- a/constants/LocationFix.json
+++ b/constants/LocationFix.json
@@ -29,6 +29,12 @@
       "b": "-435.3:115.0:-547.7",
       "island_name": "Crimson Isle",
       "real_location": "Stronghold"
+    },
+    "extendedBurningDesertArea": {
+      "a": "-445.0:80:-895.0",
+      "b": "-540.0:110:-646.0",
+      "island_name": "Crimson Isle",
+      "real_location": "Burning Desert"
     }
   }
 }


### PR DESCRIPTION
The area in crimson isles where spiders spawn is bigger than what hypixel displays as Burning Desert, and so the tarantula slayer tracker only works in part of the area