### PR TITLE
Revert "Add backpacks to hide_in_storage"

### DIFF
--- a/constants/HideNotClickableItems.json
+++ b/constants/HideNotClickableItems.json
@@ -74,12 +74,7 @@
       "Basket of Seeds",
       "Builder's Ruler",
       "Builder's Wand",
-      "Greater Backpack",
-      "Jumbo Backpack",
-      "Large Backpack",
-      "Medium Backpack",
-      "Nether Wart Pouch",
-      "Small Backpack"
+      "Nether Wart Pouch"
     ],
     "startsWith": [],
     "endsWith": [


### PR DESCRIPTION
Reverts hannibal002/SkyHanni-REPO#70

This was actually a bad idea because it tries to stop you from putting backpacks into the `/storage` menu as well. I'll redo it in a better way later.