### PR TITLE
Add Sulphur to NPC sellable items

### DIFF
--- a/constants/HideNotClickableItems.json
+++ b/constants/HideNotClickableItems.json
@@ -60,6 +60,7 @@
       "Spruce Wood Plank",
       "Spruce Wood Slab",
       "Stone Brick Slab",
+      "Sulphur",
       "Superboom TNT",
       "Toxic Arrow Poison",
       "Training Weights",


### PR DESCRIPTION
Commonly generated by minions with Corrupt Soil, and NPC price is not unreasonable compared to Bazaar.