### PR TITLE
Add Doubloon of the Family to NPC sellable items

### DIFF
--- a/constants/HideNotClickableItems.json
+++ b/constants/HideNotClickableItems.json
@@ -23,6 +23,7 @@
       "Condensed Fermento",
       "Corrupted Fragment",
       "Defuse Kit",
+      "Doubloon of the Family",
       "Enchanted Brown Mushroom",
       "Enchanted Golden Apple",
       "Enchanted Red Mushroom",


### PR DESCRIPTION
Its only purpose is, quite literally, selling to NPC. :P