### PR TITLE
Fix good enchantment level for Sunder

### DIFF
--- a/constants/Enchants.json
+++ b/constants/Enchants.json
@@ -483,7 +483,7 @@
     "sunder": {
       "loreName": "Sunder",
       "nbtName": "sunder",
-      "goodLevel": 5,
+      "goodLevel": 0,
       "maxLevel": 6
     },
     "syphon": {


### PR DESCRIPTION
This was missed in #178.

Per the logic there, it is not obtainable from the enchantment table at all, so we mark level 1 as already "great".