### PR TITLE
Fix Great Spook end time

### DIFF
--- a/constants/Events.json
+++ b/constants/Events.json
@@ -1,6 +1,6 @@
 {
   "great_spook" : {
     "start_time": 1729310400000,
-    "end_time": 1730523600000
+    "end_time": 1730520000000
   }
 }


### PR DESCRIPTION
It ends an hour earlier than currently listed in the repo.

(My timezone is UTC+1, so it ends at 4 AM UTC.)

<img width="410" alt="Screenshot of SkyBlock Menu showing active event Great Spook ending in 4h 24m (05:00 UTC+1)" src="https://github.com/user-attachments/assets/06707a46-c9e7-47b9-892e-a8a37dc1920e">
