### PR TITLE
Attribute roll changes

### DIFF
--- a/constants/AttributeGoodRolls.json
+++ b/constants/AttributeGoodRolls.json
@@ -274,14 +274,6 @@
       "regex": "MOLTEN_NECKLACE",
       "list": [
         [
-          "veteran",
-          "magic_find"
-        ],
-        [
-          "magic_find",
-          "mending"
-        ],
-        [
           "dominance",
           "speed"
         ],


### PR DESCRIPTION
magic find Veteran + Magic Find vitality rolls removed from molten necklace as rift necklace beats it.