### PR TITLE
Add rabbit textures

### DIFF
--- a/constants/HoppityRabbitTextures.json
+++ b/constants/HoppityRabbitTextures.json
@@ -198,6 +198,7 @@
           "Ace",
           "Krys",
           "Quince Quark",
+          "Savannah",
           "Thor"
         ],
         "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNDkwNjkyNSwKICAicHJvZmlsZUlkIiA6ICJmY2ZhYTg0MzA0YjE0NDUxOThkNWYxNzQ3ZjI0Y2Q5MCIsCiAgInByb2ZpbGVOYW1lIiA6ICJMYXJzVGhlV29sZiIsCiAgInNpZ25hdHVyZVJlcXVpcmVkIiA6IHRydWUsCiAgInRleHR1cmVzIiA6IHsKICAgICJTS0lOIiA6IHsKICAgICAgInVybCIgOiAiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS8xZjZkMjUxNzA0MmUxNDg1OTIxZDJkNTI4NjliMjVmZDgwMDM5MDc0YTgzZDYxNzUyZWIzMTZkOTQ3OGQ4ZGQzIgogICAgfQogIH0KfQ==",
@@ -247,6 +248,7 @@
           "Calypso",
           "Castle",
           "Kiera",
+          "Octavia",
           "Prince",
           "Punch",
           "Rochie"
@@ -358,9 +360,11 @@
       },
       {
         "rabbits": [
+          "Boulder",
           "Bugatti",
           "Cinnamon",
           "Honey",
+          "Mutonio",
           "Popcorn",
           "River",
           "Phi"
@@ -444,6 +448,7 @@
           "Fitch",
           "Gee-Gee",
           "Goofy",
+          "Grog",
           "Jazz",
           "Jelly Bean",
           "Leopold",
@@ -535,6 +540,7 @@
       {
         "rabbits": [
           "Ashes",
+          "Brick",
           "Brutus",
           "Bubbles",
           "Chilli",
@@ -700,6 +706,7 @@
           "Pebbles",
           "Porter",
           "Stinky",
+          "Striker",
           "Tagalong",
           "Theodore",
           "William",
@@ -804,6 +811,7 @@
           "Emma",
           "Eta",
           "Gracie",
+          "Kronk",
           "Mimi",
           "Mochi",
           "Mona",

--- a/constants/HoppityRabbitTextures.json
+++ b/constants/HoppityRabbitTextures.json
@@ -263,6 +263,7 @@
       },
       {
         "rabbits": [
+          "Chi",
           "Gatsby",
           "Jedi",
           "Pi",

--- a/constants/HoppityRabbitTextures.json
+++ b/constants/HoppityRabbitTextures.json
@@ -116,6 +116,14 @@
         "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNDYxMTA4NywKICAicHJvZmlsZUlkIiA6ICI4NDM2OTk1ZDhkZDM0NDVjYjk1ZGM2MDVjYWY3ZWIwOCIsCiAgInByb2ZpbGVOYW1lIiA6ICJraXR0eWNhdGtvIiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzI0MGIxYWQ1YWU0ZmM0ZDA5MjMyMTQwMzljY2IyMGVkMDM3ZTM3NzNjYzc4ZTRjMmU4NTE2YzA3NDI2NDg4ZDIiCiAgICB9CiAgfQp9",
         "skull_id": "58b79405-719d-3ae4-ad88-d70d61f0495d",
         "texture_id": "240b1ad5ae4fc4d0923214039ccb20ed037e3773cc78e4c2e8516c07426488d2"
+      },
+      {
+        "rabbits": [
+          "Omega"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxNTEwMzQwOTg0MiwKICAicHJvZmlsZUlkIiA6ICIzZGE2ZDgxOTI5MTY0MTNlODhlNzg2MjQ3NzA4YjkzZSIsCiAgInByb2ZpbGVOYW1lIiA6ICJGZXJTdGlsZSIsCiAgInNpZ25hdHVyZVJlcXVpcmVkIiA6IHRydWUsCiAgInRleHR1cmVzIiA6IHsKICAgICJTS0lOIiA6IHsKICAgICAgInVybCIgOiAiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS82MGRlZTQxOTc2ZTVkOTk1NDA4ODcwYmQ5ZmU1MDA1NmVlYzQzYmNiNGU3YjEyMjJmNTk5YzFlNmZhYjU5NzczIgogICAgfQogIH0KfQ==",
+        "skull_id": "98134e00-334d-3ea3-8fe7-43aa7b7cf57b",
+        "texture_id": "60dee41976e5d995408870bd9fe50056eec43bcb4e7b1222f599c1e6fab59773"
       }
     ],
     "legendary": [
@@ -158,6 +166,7 @@
         "rabbits": [
           "Epsilon",
           "Houdini",
+          "Psi",
           "Shadow"
         ],
         "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNDgwOTM2MSwKICAicHJvZmlsZUlkIiA6ICJmYmFkNTg0ZmEyYTA0MjZhODZmMzgyMGFhZGEwOWVkZCIsCiAgInByb2ZpbGVOYW1lIiA6ICJTb2xpZFRvYXN0ZSIsCiAgInNpZ25hdHVyZVJlcXVpcmVkIiA6IHRydWUsCiAgInRleHR1cmVzIiA6IHsKICAgICJTS0lOIiA6IHsKICAgICAgInVybCIgOiAiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS8zYTE1YzA0Yjk5YmZkNWRjODUxMWM2NGQ5MWY0MzkzMDc0ZGNmMTlhMTY4OWQ4M2MzZjg4ZTMwOTM2ODU5ZWUiCiAgICB9CiAgfQp9",
@@ -232,6 +241,7 @@
         "rabbits": [
           "Angel",
           "Comet",
+          "Dojo",
           "Maxima",
           "Necron",
           "Peppermint Pearl",
@@ -289,6 +299,7 @@
           "Aladdin",
           "Blackjack",
           "Cajun",
+          "Coltron",
           "Dallas",
           "Draco",
           "Elvis",
@@ -434,6 +445,7 @@
           "Alexa",
           "Asterix",
           "Average",
+          "Azure",
           "Benji",
           "Beta",
           "Blossom",
@@ -452,6 +464,7 @@
           "Jazz",
           "Jelly Bean",
           "Leopold",
+          "Orchid",
           "Patches",
           "Rusty",
           "Sweetpea",
@@ -584,6 +597,7 @@
           "Cassidy",
           "Gadget",
           "Oakley",
+          "Oakly",
           "Otto",
           "Polka Dot",
           "Prudent",
@@ -695,6 +709,7 @@
           "Heidie",
           "Hopper",
           "Indie",
+          "Jacqueline",
           "Jake",
           "Jasmine",
           "Joey",

--- a/constants/HoppityRabbitTextures.json
+++ b/constants/HoppityRabbitTextures.json
@@ -633,6 +633,7 @@
           "Lily",
           "Max",
           "Miles",
+          "Motfer",
           "Natalie",
           "Ollie",
           "Razzie",

--- a/constants/HoppityRabbitTextures.json
+++ b/constants/HoppityRabbitTextures.json
@@ -398,6 +398,7 @@
           "Sage",
           "Spirit",
           "Tornado",
+          "Towny",
           "Wesson",
           "Willow"
         ],
@@ -800,6 +801,7 @@
           "Cocoa Comet",
           "Dulce Drizzle",
           "Ellie",
+          "Emma",
           "Eta",
           "Gracie",
           "Mimi",

--- a/constants/HoppityRabbitTextures.json
+++ b/constants/HoppityRabbitTextures.json
@@ -1,0 +1,831 @@
+{
+  "textures": {
+    "divine": [
+      {
+        "rabbits": [
+          "Aurora",
+          "Orion",
+          "Vega"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxNTEwMzEyMDU4MSwKICAicHJvZmlsZUlkIiA6ICI3NzUwYzFhNTM5M2Q0ZWQ0Yjc2NmQ4ZGUwOWY4MjU0NiIsCiAgInByb2ZpbGVOYW1lIiA6ICJSZWVkcmVsIiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2Q0Y2I0NzBjMzExNGNjMjIwM2ZhMDk3MDhhMDc5NTE3OTM3NmI4MDM5ZjcyOGUxODI2NjRmNzM0ODU2MDAzMGQiCiAgICB9CiAgfQp9",
+        "skull_id": "9a322501-c9f4-3f57-89e4-c0c1f9721081",
+        "texture_id": "d4cb470c3114cc2203fa09708a0795179376b8039f728e182664f7348560030d"
+      },
+      {
+        "rabbits": [
+          "Celestia"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxNTEwMzA0NzIwNywKICAicHJvZmlsZUlkIiA6ICJlZTg4M2RmMjM0ZWI0YWM1YTFlNDEwODhhYzZkZWIxNyIsCiAgInByb2ZpbGVOYW1lIiA6ICJUdW5lc0Jsb2NrIiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2JmYzQ3MWUwMThiZjQzZjMxNWIwMGVjNDE5YWU3YTdmOWRlNjY5MDQ0NGIzMGU5ZTVkMzRjZjc5YTMxNmMwMjMiCiAgICB9CiAgfQp9",
+        "skull_id": "4e2dea5e-25f9-35b5-b4b1-883347d584e9",
+        "texture_id": "bfc471e018bf43f315b00ec419ae7a7f9de6690444b30e9e5d34cf79a316c023"
+      },
+      {
+        "rabbits": [
+          "Starfire"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxNTEwMzA4NjMyMSwKICAicHJvZmlsZUlkIiA6ICJlMzcxMWU2Y2E0ZmY0NzA4YjY5ZjhiNGZlYzNhZjdhMSIsCiAgInByb2ZpbGVOYW1lIiA6ICJNckJ1cnN0IiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzg5MmMxZTdiN2IxM2EzNzg2MTFhMzZhMjYxZmZmN2Y4YWEwNjU4ZGFhOGFmNDZiYWE1MzQxYTc4N2NiNWU3MGIiCiAgICB9CiAgfQp9",
+        "skull_id": "776c6fa8-0783-3a2e-9831-d067ac0fc516",
+        "texture_id": "892c1e7b7b13a378611a36a261fff7f8aa0658daa8af46baa5341a787cb5e70b"
+      }
+    ],
+    "mythic": [
+      {
+        "rabbits": [
+          "Dante"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNDU5MjQ3OSwKICAicHJvZmlsZUlkIiA6ICIwNTljODIxYzhhODU0NGJiOWJiODVhOGMxNjVhYTc5YiIsCiAgInByb2ZpbGVOYW1lIiA6ICJoZWxsc3RydWNrZWR6IiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzkyMWZhN2I3ODZlNjNjMGVhYzlhNWYwOTllYWJmYjBlMjg5OTM0NDMzZjBiMWRkODU3MDNhZmI5Mzg5ODE5NTIiCiAgICB9CiAgfQp9",
+        "skull_id": "12e09312-e7ab-321c-b62c-60667807c2ce",
+        "texture_id": "921fa7b786e63c0eac9a5f099eabfb0e289934433f0b1dd85703afb938981952"
+      },
+      {
+        "rabbits": [
+          "Einstein"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNDYzMTQzNiwKICAicHJvZmlsZUlkIiA6ICIyMmNiM2U0ZDdmOTY0ZmNjYjE1MDIyNWIwN2YzMTEyMCIsCiAgInByb2ZpbGVOYW1lIiA6ICJ0dWxleW1hbkIiLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNzcxZjNhOTZmMjJjOWQ2MjRiNTY0ZDk5MDU5Yzk1NzU5MmNhNWE5ODRlNjlhNmY2ZmIzNmU1M2FjMDcwYTZkMiIKICAgIH0KICB9Cn0=",
+        "skull_id": "049d7949-850e-376f-b39d-be4158dd4f16",
+        "texture_id": "771f3a96f22c9d624b564d99059c957592ca5a984e69a6f6fb36e53ac070a6d2"
+      },
+      {
+        "rabbits": [
+          "Galaxy"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNDY1MTQ3NywKICAicHJvZmlsZUlkIiA6ICJlZDUzZGQ4MTRmOWQ0YTNjYjRlYjY1MWRjYmE3N2U2NiIsCiAgInByb2ZpbGVOYW1lIiA6ICI0MTQxNDE0MWgiLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvY2QxNjk1YTEzYmZmMmY4ZTExNjkyYzg2OTIxODg3YmY5MTE3YTFhNGRjOWU1ZmU0NDViNmM4YTg3NjRlNDFmZSIKICAgIH0KICB9Cn0=",
+        "skull_id": "d9eb5306-460c-3f11-95e8-bc021618beba",
+        "texture_id": "cd1695a13bff2f8e11692c86921887bf9117a1a4dc9e5fe445b6c8a8764e41fe"
+      },
+      {
+        "rabbits": [
+          "King"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNDY3MzgwOSwKICAicHJvZmlsZUlkIiA6ICJiM2IyNDdhMzRkMWY0M2YzOTg2OTMyZDM0ZmViZWFlNiIsCiAgInByb2ZpbGVOYW1lIiA6ICJMYXB0eSIsCiAgInNpZ25hdHVyZVJlcXVpcmVkIiA6IHRydWUsCiAgInRleHR1cmVzIiA6IHsKICAgICJTS0lOIiA6IHsKICAgICAgInVybCIgOiAiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS85NjUxMzYxMjc1Zjc5ZmVlZjYxNGE3NjVlZWI3MTczNGE3Mzk5NmEyNWU5ZThlODQ2MDhkZTA2M2YzODYwMjMiCiAgICB9CiAgfQp9",
+        "skull_id": "fc880af4-e72b-33cb-adc8-52ed5aaaa181",
+        "texture_id": "9651361275f79feef614a765eeb71734a73996a25e9e8e84608de063f386023"
+      },
+      {
+        "rabbits": [
+          "Mu"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxNTEwMzM3MTU2OCwKICAicHJvZmlsZUlkIiA6ICIyMDZlMWZkYjI5Yzk0NGYxOTQ5OTg4NzAwNTQxMGQ2NyIsCiAgInByb2ZpbGVOYW1lIiA6ICJoNHlsMzMiLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYWM5NzFkMDU1MDU4ZTBlYjEwYzNjYjM0Mjg5NzRlMDZkNDBmOWQ0NjQwYmNlMjc0NzUyOTVhMTgzZTkwMTY2YyIKICAgIH0KICB9Cn0=",
+        "skull_id": "b2e8e3bd-fe37-3023-af7b-b8e9f47b6866",
+        "texture_id": "ac971d055058e0eb10c3cb3428974e06d40f9d4640bce27475295a183e90166c"
+      },
+      {
+        "rabbits": [
+          "Napoleon"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNDU3NzAwNiwKICAicHJvZmlsZUlkIiA6ICIxMzEzZGFmMDc2OGQ0YmQ5Yjc1ODJkMGI1NWUwZGQxNiIsCiAgInByb2ZpbGVOYW1lIiA6ICJMZW50aWNjaGllIiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzU2MDcwNzk0MDdiZWE1ZWRiNTJkZjliM2IzYTU0ZDJkNjIyYmJmMWU1OWYxMTc0NTZmMWJlYjMwYThjYmFkOGYiCiAgICB9CiAgfQp9",
+        "skull_id": "f4da4b23-89e1-3688-845d-5be64579038a",
+        "texture_id": "5607079407bea5edb52df9b3b3a54d2d622bbf1e59f117456f1beb30a8cbad8f"
+      },
+      {
+        "rabbits": [
+          "Omega"
+        ],
+        "texture_value_b64": "",
+        "skull_id": "",
+        "texture_id": ""
+      },
+      {
+        "rabbits": [
+          "Sigma"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxNTEwMzM5MDU1NywKICAicHJvZmlsZUlkIiA6ICI5NTQ1NGYzOTkwNGE0MDg0OTcxMTQ0Y2Q5MmRhY2MyYSIsCiAgInByb2ZpbGVOYW1lIiA6ICJHcDA4MTAiLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZmNjODY1NWY4MTI0NWUzMGZiN2Y4YzI4MjcwZTY4NTIzYzBjMDhhNzE1Y2IyNDgwMmJjM2NkY2M5YmVhOGIxNSIKICAgIH0KICB9Cn0",
+        "skull_id": "213d1b5c-7132-31cb-a893-3b364e3ee2e2",
+        "texture_id": "fcc8655f81245e30fb7f8c28270e68523c0c08a715cb24802bc3cdcc9bea8b15"
+      },
+      {
+        "rabbits": [
+          "Zest Zephyr"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTk3OTU2OTU0NCwKICAicHJvZmlsZUlkIiA6ICI5ZDE1OGM1YjNiN2U0ZGNlOWU0OTA5MTdjNmJlYmM5MSIsCiAgInByb2ZpbGVOYW1lIiA6ICJTbm9uX1NTIiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzIyNzM5MjQzNzY5YzllODgwNzEyYTk1YjY2YTg2ZmYwNDk1NTZjMTIzYTA1M2FkYzJmZDUwZjcxOWMwZjEyMjgiCiAgICB9CiAgfQp9",
+        "skull_id": "71a43560-c5d8-3e17-99ea-d9596278f3eb",
+        "texture_id": "22739243769c9e880712a95b66a86ff049556c123a053adc2fd50f719c0f1228"
+      },
+      {
+        "rabbits": [
+          "Zeta"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxNTEwMzM0ODczNywKICAicHJvZmlsZUlkIiA6ICI3OTZjMDBhNmY0MDA0Mjg2OWMyMTIyNjc0ZmI0MWNiZSIsCiAgInByb2ZpbGVOYW1lIiA6ICJTZWRvbnlhIiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzUwZGU1NDVmN2M0MGE2ZWM4ODhhZTNjZjlhZTk4M2Q5Mjc4OWRmNzc4Y2Y1NWQ5ZjVhM2QzY2IzYzZkMWI3NjgiCiAgICB9CiAgfQp9",
+        "skull_id": "aa834561-cabc-3d33-8d0a-5d01342e796b",
+        "texture_id": "50de545f7c40a6ec888ae3cf9ae983d92789df778cf55d9f5a3d3cb3c6d1b768"
+      },
+      {
+        "rabbits": [
+          "Zorro"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNDYxMTA4NywKICAicHJvZmlsZUlkIiA6ICI4NDM2OTk1ZDhkZDM0NDVjYjk1ZGM2MDVjYWY3ZWIwOCIsCiAgInByb2ZpbGVOYW1lIiA6ICJraXR0eWNhdGtvIiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzI0MGIxYWQ1YWU0ZmM0ZDA5MjMyMTQwMzljY2IyMGVkMDM3ZTM3NzNjYzc4ZTRjMmU4NTE2YzA3NDI2NDg4ZDIiCiAgICB9CiAgfQp9",
+        "skull_id": "58b79405-719d-3ae4-ad88-d70d61f0495d",
+        "texture_id": "240b1ad5ae4fc4d0923214039ccb20ed037e3773cc78e4c2e8516c07426488d2"
+      }
+    ],
+    "legendary": [
+      {
+        "rabbits": [
+          "Apollo",
+          "Extra",
+          "Nova",
+          "Rho",
+          "Ube Unicorn",
+          "Walnut Whirl"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNDY5Mzg3NCwKICAicHJvZmlsZUlkIiA6ICIzOTg5OGFiODFmMjU0NmQxOGIyY2ExMTE1MDRkZGU1MCIsCiAgInByb2ZpbGVOYW1lIiA6ICI4YjJjYTExMTUwNGRkZTUwIiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzg3Y2U0MGU0YjI5OWIyMDhmZDFjYTIyMjgzOWU4MDg5MTg5Y2JjZjFmM2YyY2UyM2MwM2M2MDBjNjU1OWYwZjciCiAgICB9CiAgfQp9",
+        "skull_id": "9b6181db-ae04-3186-ac47-5459d2c72152",
+        "texture_id": "87ce40e4b299b208fd1ca222839e8089189cbcf1f3f2ce23c03c600c6559f0f7"
+      },
+      {
+        "rabbits": [
+          "April",
+          "Echo",
+          "Lambda",
+          "Mystic"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNDczMzcwMCwKICAicHJvZmlsZUlkIiA6ICIxNmJhNWU4MDJhMmU0ZDJhYjEwZmZiYWJiYmQ1MDdlZSIsCiAgInByb2ZpbGVOYW1lIiA6ICJzbGlua3l1c2VyMzMxNSIsCiAgInNpZ25hdHVyZVJlcXVpcmVkIiA6IHRydWUsCiAgInRleHR1cmVzIiA6IHsKICAgICJTS0lOIiA6IHsKICAgICAgInVybCIgOiAiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS81ZWUzZWUyYzA5ZWE3Yjg4YjU2MjQ3ZGM4YzNjYjQ5ZGZlZDQ1ZWI3NmQzOTZjNTNmMTFhNDljYWY1YTcxOWM5IgogICAgfQogIH0KfQ==",
+        "skull_id": "1d109a3b-ec68-3cf8-9b10-145239e0e721",
+        "texture_id": "5ee3ee2c09ea7b88b56247dc8c3cb49dfed45eb76d396c53f11a49caf5a719c9"
+      },
+      {
+        "rabbits": [
+          "Atlas",
+          "El Dorado",
+          "Magic",
+          "Storm"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNDc1NTM1NCwKICAicHJvZmlsZUlkIiA6ICI5YzM5OTdhMjVjNWY0NmY0OWZlMWFhY2RlZjRiMmMwNSIsCiAgInByb2ZpbGVOYW1lIiA6ICJLaWxsZXJmcmVkZHk4OTQiLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNGUxYzE3MGI0ZjZjMzc2MTRlZTk2MDk2MDE2NDg1NWFiNzQyNmNlZmI0NDA5N2Y3OTU3ZmEzMGE2N2I5MzVlZiIKICAgIH0KICB9Cn0=",
+        "skull_id": "c9e8c770-e87b-3593-ba6f-2991b5d42872",
+        "texture_id": "4e1c170b4f6c37614ee960960164855ab7426cefb44097f7957fa30a67b935ef"
+      },
+      {
+        "rabbits": [
+          "Epsilon",
+          "Houdini",
+          "Shadow"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNDgwOTM2MSwKICAicHJvZmlsZUlkIiA6ICJmYmFkNTg0ZmEyYTA0MjZhODZmMzgyMGFhZGEwOWVkZCIsCiAgInByb2ZpbGVOYW1lIiA6ICJTb2xpZFRvYXN0ZSIsCiAgInNpZ25hdHVyZVJlcXVpcmVkIiA6IHRydWUsCiAgInRleHR1cmVzIiA6IHsKICAgICJTS0lOIiA6IHsKICAgICAgInVybCIgOiAiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS8zYTE1YzA0Yjk5YmZkNWRjODUxMWM2NGQ5MWY0MzkzMDc0ZGNmMTlhMTY4OWQ4M2MzZjg4ZTMwOTM2ODU5ZWUiCiAgICB9CiAgfQp9",
+        "skull_id": "693852c2-2589-36b7-a8b0-ddc6acfd335b",
+        "texture_id": "3a15c04b99bfd5dc8511c64d91f4393074dcf19a1689d83c3f88e30936859ee"
+      },
+      {
+        "rabbits": [
+          "General"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNDc3MzEyNiwKICAicHJvZmlsZUlkIiA6ICIzYTA3ZWJmNGI1NTA0ZjJiYTAxZTVhOGU5NmQxM2I0YSIsCiAgInByb2ZpbGVOYW1lIiA6ICJsZWxhc3lhIiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2M5NTE5MmY0OGE0MmI2ZGM3OGNjYjczMWJjNTVlOGFmNzY4M2EyMmYxNDM5NDFiNDE2N2ZmMGI1MGQ5ZTQ2MjkiCiAgICB9CiAgfQp9",
+        "skull_id": "f2a8cedd-817a-359e-98e4-1dfdf8c30455",
+        "texture_id": "c95192f48a42b6dc78ccb731bc55e8af7683a22f143941b4167ff0b50d9e4629"
+      },
+      {
+        "rabbits": [
+          "Solomon",
+          "Vanilla Vortex",
+          "Yogurt Yucca"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNDcxMjY3MywKICAicHJvZmlsZUlkIiA6ICI1NzgzZWMxNDgxMDI0ZDJmOTk4N2JhNGZhNWNlMmFmOCIsCiAgInByb2ZpbGVOYW1lIiA6ICJCbHVlUGhlbml4NDMiLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNWYyYzIwOTc2ODZhM2EyZjY1YjIwOGY5OWQwNDk0NWMxNzA3OGMzOWMxODc5MTVmOTQwZmFiOTU3ZTcyOTY0MCIKICAgIH0KICB9Cn0=",
+        "skull_id": "35361a35-848d-3ff0-bc74-c0afbce29f77",
+        "texture_id": "5f2c2097686a3a2f65b208f99d04945c17078c39c187915f940fab957e729640"
+      },
+      {
+        "rabbits": [
+          "Xoco Xanadu",
+          "Kaeman"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNDc5Mzc5MiwKICAicHJvZmlsZUlkIiA6ICIxMTM1Njg1ZTk3ZGE0ZjYyYTliNDQ3MzA0NGFiZjQ0MSIsCiAgInByb2ZpbGVOYW1lIiA6ICJNYXJpb1dsZXMiLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvODJlYTIwMjA2Y2E0NmQzMTlhNGY5MWQ1NmEzY2FkMzI3ZTU1MzkxMGEyNmUwMTI4YmM3NGJlMWVmZGRhZjk4NiIKICAgIH0KICB9Cn0=",
+        "skull_id": "39f26b12-105d-38c1-bba3-eb2a1c2192b7",
+        "texture_id": "82ea20206ca46d319a4f91d56a3cad327e553910a26e0128bc74be1efddaf986"
+      }
+    ],
+    "epic": [
+      {
+        "rabbits": [
+          "Ace",
+          "Quince Quark",
+          "Thor"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNDkwNjkyNSwKICAicHJvZmlsZUlkIiA6ICJmY2ZhYTg0MzA0YjE0NDUxOThkNWYxNzQ3ZjI0Y2Q5MCIsCiAgInByb2ZpbGVOYW1lIiA6ICJMYXJzVGhlV29sZiIsCiAgInNpZ25hdHVyZVJlcXVpcmVkIiA6IHRydWUsCiAgInRleHR1cmVzIiA6IHsKICAgICJTS0lOIiA6IHsKICAgICAgInVybCIgOiAiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS8xZjZkMjUxNzA0MmUxNDg1OTIxZDJkNTI4NjliMjVmZDgwMDM5MDc0YTgzZDYxNzUyZWIzMTZkOTQ3OGQ4ZGQzIgogICAgfQogIH0KfQ==",
+        "skull_id": "a0687036-13d5-318b-adc9-d32091c59583",
+        "texture_id": "1f6d2517042e1485921d2d52869b25fd80039074a83d61752eb316d9478d8dd3"
+      },
+      {
+        "rabbits": [
+          "Achilles",
+          "Kappa"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNDkzMDc1NCwKICAicHJvZmlsZUlkIiA6ICI2NGRiNmMwNTliOTk0OTM2YTY0M2QwODEwODE0ZmJkMyIsCiAgInByb2ZpbGVOYW1lIiA6ICJUaGVTaWx2ZXJEcmVhbXMiLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMTg5ODkxNjRkZmM2MDQ3YjQ3ZjRkNjlmMGZmMjM4NmE0YmJhNGUxYjA4ZWE3NmIzNzc3N2JkMDhiOWMxZjVjOSIKICAgIH0KICB9Cn0=",
+        "skull_id": "65fd4886-8b37-394d-8ad4-6cc0ab850c10",
+        "texture_id": "18989164dfc6047b47f4d69f0ff2386a4bba4e1b08ea76b37777bd08b9c1f5c9"
+      },
+      {
+        "rabbits": [
+          "Alpine",
+          "Implode",
+          "Rambo",
+          "Saga",
+          "Strawberry Swirl",
+          "Turbo"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNDgyODA5MywKICAicHJvZmlsZUlkIiA6ICI2YTE1NjRiMWY5NzM0NWIzOTNlNWU3N2UwMjU1YWZjNiIsCiAgInByb2ZpbGVOYW1lIiA6ICJEYXJrX0h1IiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzNlMGFhOTU2MGU2MTAyY2FmYjczY2IxOGEzZjUwMTUwZjJkNWYxN2IzOTNiYjNjYTlmNzJmYmQ4Mzg4MDViN2UiCiAgICB9CiAgfQp9",
+        "skull_id": "8832b9b8-15eb-3c23-bb67-2a813718be4e",
+        "texture_id": "3e0aa9560e6102cafb73cb18a3f50150f2d5f17b393bb3ca9f72fbd838805b7e"
+      },
+      {
+        "rabbits": [
+          "Angel",
+          "Comet",
+          "Necron",
+          "Peppermint Pearl",
+          "Toffee Tulip",
+          "Trix"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNDg2ODU1OCwKICAicHJvZmlsZUlkIiA6ICIyMWNjMzkxZmNkMjc0NzY5OTg5Y2M3M2VjYWRiNTE3YiIsCiAgInByb2ZpbGVOYW1lIiA6ICJHT1NUTFk5NyIsCiAgInNpZ25hdHVyZVJlcXVpcmVkIiA6IHRydWUsCiAgInRleHR1cmVzIiA6IHsKICAgICJTS0lOIiA6IHsKICAgICAgInVybCIgOiAiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS9lMWIwMzUzYWVhMzdkYzQ1MTRkZGYxZjY0MWY1ZTRjZDIwMjhkN2FmODU4NGZhNGM2ZWE1YjA5ZmQ0ODliZGEwIgogICAgfQogIH0KfQ==",
+        "skull_id": "585c3f61-915b-3a51-a4f5-22043510bb9c",
+        "texture_id": "e1b0353aea37dc4514ddf1f641f5e4cd2028d7af8584fa4c6ea5b09fd489bda0"
+      },
+      {
+        "rabbits": [
+          "Calypso",
+          "Kiera",
+          "Prince",
+          "Punch"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNDg1MTg3NSwKICAicHJvZmlsZUlkIiA6ICJkZTU3MWExMDJjYjg0ODgwOGZlN2M5ZjQ0OTZlY2RhZCIsCiAgInByb2ZpbGVOYW1lIiA6ICJNSEZfTWluZXNraW4iLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNzdiY2Q2YTAwZjgxNGIyNWQ2YjI1ZTFhMmI3YzhkN2NjOWY3N2NlZmM2ZjBjMWJhM2Q1OWVkOGRiYWIyMjY3NSIKICAgIH0KICB9Cn0=",
+        "skull_id": "407f7b1a-d0a8-31c3-8cf8-e60bbddab1f1",
+        "texture_id": "77bcd6a00f814b25d6b25e1a2b7c8d7cc9f77cefc6f0c1ba3d59ed8dbab22675"
+      },
+      {
+        "rabbits": [
+          "Delta",
+          "Ken",
+          "Kodo",
+          "Merlin",
+          "Raspberry Ripple"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNDk2NzA3NCwKICAicHJvZmlsZUlkIiA6ICI0NDAzZGM1NDc1YmM0YjE1YTU0OGNmZGE2YjBlYjdkOSIsCiAgInByb2ZpbGVOYW1lIiA6ICJTdGFja092ZXJmbG93RXJyIiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2RlOGVjM2FiOGM5ODRhY2Y3MDkyYjBmODFmNDk0OThkOTUwNzcwNjFjNjgwMjM0ODZiMzU0NTViZTVmZDdkMjQiCiAgICB9CiAgfQp9",
+        "skull_id": "ce02e568-f297-37c2-bb42-8f477174daf4",
+        "texture_id": "de8ec3ab8c984acf7092b0f81f49498d95077061c68023486b35455be5fd7d24"
+      },
+      {
+        "rabbits": [
+          "Gatsby",
+          "Jedi",
+          "Pi",
+          "Simba"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNDg4OTY5NywKICAicHJvZmlsZUlkIiA6ICIzYmFlMTVhMWU0Zjg0ZTc5OWE3N2QwZDBhZTNlZDc5NiIsCiAgInByb2ZpbGVOYW1lIiA6ICJiYXlyb25fZ2FtZXJfMjU0IiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzMzNmYwYTUxY2ZiMTBiODE5ZGUxZmNkZjM0NzBmM2QzMzZkYjI2MWQxZmZiYTk0M2E3ODU2NTQwODA5ZGI0ZWUiCiAgICB9CiAgfQp9",
+        "skull_id": "217a75ba-42a7-3cf9-b366-35c07316942b",
+        "texture_id": "336f0a51cfb10b819de1fcdf3470f3d336db261d1ffba943a7856540809db4ee"
+      }
+    ],
+    "rare": [
+      {
+        "rabbits": [
+          "Aladdin",
+          "Blackjack",
+          "Cajun",
+          "Dallas",
+          "Draco",
+          "Elvis",
+          "Gamma",
+          "Gremlin",
+          "Jynx",
+          "Phantom",
+          "Snowball"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNDk4NDIwMywKICAicHJvZmlsZUlkIiA6ICJhNzQ0NWIzOTdkMWY0ZjBiOTNkYTMwNGZjY2M2OTM1MiIsCiAgInByb2ZpbGVOYW1lIiA6ICJFc2tyYVRlVCIsCiAgInNpZ25hdHVyZVJlcXVpcmVkIiA6IHRydWUsCiAgInRleHR1cmVzIiA6IHsKICAgICJTS0lOIiA6IHsKICAgICAgInVybCIgOiAiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS9mOWFlNjk0ODI4NDIwYTJiNWJjMDlkNGE4MjM2NzE0OGZjYzNiODI5MWZkYjgyMjY4ODM0ZGFhOGU5ZmI2ZTczIgogICAgfQogIH0KfQ==",
+        "skull_id": "40d3b7da-0f2c-3dda-a686-f226fb7be336",
+        "texture_id": "f9ae694828420a2b5bc09d4a82367148fcc3b8291fdb82268834daa8e9fb6e73"
+      },
+      {
+        "rabbits": [
+          "Aloysius",
+          "Blackberry",
+          "Burst",
+          "Caramel",
+          "Figaro",
+          "Kiwi Kiss",
+          "Orange Obsidian",
+          "Pride",
+          "Spooky",
+          "Sunny",
+          "Widget"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNTI2MDk3MCwKICAicHJvZmlsZUlkIiA6ICI1OGZmZWI5NTMxNGQ0ODcwYTQwYjVjYjQyZDRlYTU5OCIsCiAgInByb2ZpbGVOYW1lIiA6ICJTa2luREJuZXQiLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMmVkMDU2OTQxNjRiMTUyYTQ0ZjA1M2MyOTMxZDkxNmI2NmY1NzY0YTQ0ZDdiM2I4ZTcwNTJmNTI1NWJmNWU0MiIKICAgIH0KICB9Cn0=",
+        "skull_id": "c2a9ae42-4d3c-3365-baa2-247923535196",
+        "texture_id": "2ed05694164b152a44f053c2931d916b66f5764a44d7b3b8e7052f5255bf5e42"
+      },
+      {
+        "rabbits": [
+          "Barbie",
+          "Casanova",
+          "Chevy",
+          "Easter",
+          "Hope",
+          "Lavender Lemon",
+          "Linus",
+          "Monalisa",
+          "Olympe",
+          "Onyx",
+          "Paddington"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNTI0MDkwNCwKICAicHJvZmlsZUlkIiA6ICJmY2ZhYTg0MzA0YjE0NDUxOThkNWYxNzQ3ZjI0Y2Q5MCIsCiAgInByb2ZpbGVOYW1lIiA6ICJMYXJzVGhlV29sZiIsCiAgInNpZ25hdHVyZVJlcXVpcmVkIiA6IHRydWUsCiAgInRleHR1cmVzIiA6IHsKICAgICJTS0lOIiA6IHsKICAgICAgInVybCIgOiAiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS80NTZhMjA5ODAzZTFlOGViOTQxMTc3ZTJjYzhhMDFiY2VhODg0ZDk0ZGM3N2MzOGUyMmY1Y2QxYTg2MmY4OWNhIgogICAgfQogIH0KfQ==",
+        "skull_id": "dce6b1ed-8965-3589-b61b-87a61dbbadc3",
+        "texture_id": "456a209803e1e8eb941177e2cc8a01bcea884d94dc77c38e22f5cd1a862f89ca"
+      },
+      {
+        "rabbits": [
+          "Bishop",
+          "Iota",
+          "Murphy",
+          "Neptune",
+          "Omicron",
+          "Orlando",
+          "Pumpkin",
+          "Tricky"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNTMwMzY1OCwKICAicHJvZmlsZUlkIiA6ICI0MDNlYmEzYjhkODg0MDVlYjhjMDlkNTQ4NmFjYzdiZSIsCiAgInByb2ZpbGVOYW1lIiA6ICJWb3J0ZXh0dHYiLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZWI3OTIxMzhjMmU4MmU0OTIxMTZlYzg4MmE3ZDA3Nzg2OGYzNWViOTY5ZDU4NjgwN2I0OGZlNjhkNmM1Y2JlYSIKICAgIH0KICB9Cn0=",
+        "skull_id": "6c3927ac-d62a-3d77-867d-e2f3419c5aee",
+        "texture_id": "eb792138c2e82e492116ec882a7d077868f35eb969d586807b48fe68d6c5cbea"
+      },
+      {
+        "rabbits": [
+          "Bugatti",
+          "Cinnamon",
+          "Honey",
+          "Popcorn",
+          "River",
+          "Phi"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNTA0MjM0NiwKICAicHJvZmlsZUlkIiA6ICI4YjRkYTFkNGIxMzU0YjQ1YjRhNWIzZDUxNGVkNGMzMiIsCiAgInByb2ZpbGVOYW1lIiA6ICJTZWxldmVyT1AxMiIsCiAgInNpZ25hdHVyZVJlcXVpcmVkIiA6IHRydWUsCiAgInRleHR1cmVzIiA6IHsKICAgICJTS0lOIiA6IHsKICAgICAgInVybCIgOiAiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS83YTkwNzAxMjVjMTE5Y2Y2MWE3ODllZjRmNTU3NzFiYzdkODFlOGQ3NjdkMjJjYzRjYmE2NTc0NzBkMjViODNmIgogICAgfQogIH0KfQ==",
+        "skull_id": "982edcdc-d583-3501-b2e3-98b872c1dedc",
+        "texture_id": "7a9070125c119cf61a789ef4f55771bc7d81e8d767d22cc4cba657470d25b83f"
+      },
+      {
+        "rabbits": [
+          "Bun Bun",
+          "Maple Mirage",
+          "Midnight",
+          "Peanut",
+          "Stormy",
+          "Uncle Buck",
+          "Vlad",
+          "Zero"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNTI4MTkyOCwKICAicHJvZmlsZUlkIiA6ICJiZDNhNWRmY2ZkZjg0NDczOTViZDJiZmUwNGY0YzAzMiIsCiAgInByb2ZpbGVOYW1lIiA6ICJwcmVja3Jhc25vIiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2RkOTlkNzBjYTZmMTM4NTI5N2U4Y2FmMzVjMDQ5NDBmZWM4MGM3MDNmMWNiYjAyNzIwYWZlNDNlNDhjNzVlZWEiCiAgICB9CiAgfQp9",
+        "skull_id": "ed122c7b-c189-3492-8ae5-d0e08d89228d",
+        "texture_id": "dd99d70ca6f1385297e8caf35c04940fec80c703f1cbb02720afe43e48c75eea"
+      },
+      {
+        "rabbits": [
+          "Crystal",
+          "Favor",
+          "Frodo",
+          "Hyde",
+          "Jasper",
+          "Nougat Nebula",
+          "Pepper",
+          "Sage",
+          "Spirit",
+          "Tornado",
+          "Wesson",
+          "Willow"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNTMyNDkwNywKICAicHJvZmlsZUlkIiA6ICJkYzA5MjA4MTM2ZDg0Y2Y5OWIwMzFmMGI1NzM4OTdmNSIsCiAgInByb2ZpbGVOYW1lIiA6ICJLRUlUSF8wMzAyIiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzExNDZlMjNhYjRhYTg4ZjE5YTg1NDY5ZWY1NWI4ZmFhZjFhZmZhMGYwZjBhMzcwNDUxZjZkNDliNzFmYWQyODAiCiAgICB9CiAgfQp9",
+        "skull_id": "6f299087-c1d8-3a80-89a1-650fef4294f4",
+        "texture_id": "1146e23ab4aa88f19a85469ef55b8faaf1affa0f0f0a370451f6d49b71fad280"
+      },
+      {
+        "rabbits": [
+          "Fish the Rabbit"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxNDk1ODk5MjUzNywKICAicHJvZmlsZUlkIiA6ICI4YmM3MjdlYThjZjA0YWUzYTI4MDVhY2YzNjRjMmQyNCIsCiAgInByb2ZpbGVOYW1lIiA6ICJub3RpbnZlbnRpdmUiLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZGI4Yzc3ODllYzkzNmQxMWU1NDFjNjk1Y2U1M2QwNWNmODNmOGMwNGMxNDhhMGIwZDg1Njc5Y2NhMTE0YTBmOSIKICAgIH0KICB9Cn0=",
+        "skull_id": "09600575-112b-3709-98c5-1220039ae5f8",
+        "texture_id": "db8c7789ec936d11e541c695ce53d05cf83f8c04c148a0b0d85679cca114a0f9"
+      },
+      {
+        "rabbits": [
+          ""
+        ],
+        "texture_value_b64": "",
+        "skull_id": "",
+        "texture_id": ""
+      }
+    ],
+    "uncommon": [
+      {
+        "rabbits": [
+          "Abi",
+          "Alexa",
+          "Asterix",
+          "Average",
+          "Benji",
+          "Beta",
+          "Blossom",
+          "Bugs",
+          "Cooper",
+          "Cotton Puff",
+          "Dalton",
+          "Dandelion",
+          "Darla",
+          "Demetrious",
+          "Fitch",
+          "Gee-Gee",
+          "Goofy",
+          "Jazz",
+          "Jelly Bean",
+          "Leopold",
+          "Patches",
+          "Rusty",
+          "Sweetpea",
+          "Theta",
+          "Void"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNTE5NjAxMCwKICAicHJvZmlsZUlkIiA6ICI4ZjE5NjJmYzE4NzY0MDU3ODYxMmIxMzNjODE4YmY5OSIsCiAgInByb2ZpbGVOYW1lIiA6ICJOaW9uXzkiLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNDFiMTAzMjdmN2Y4NzNlNzlmNWIxMmZjYmMxZGE5NDYzOGIwM2MyZjJkODFhMDhmMzk0MGEyMDc0NjAxMjM3OCIKICAgIH0KICB9Cn0=",
+        "skull_id": "e1594281-80de-304b-9f26-142f8ef2ab32",
+        "texture_id": "41b10327f7f873e79f5b12fcbc1da94638b03c2f2d81a08f3940a20746012378"
+      },
+      {
+        "rabbits": [
+          "Abigail",
+          "Amazon",
+          "Buffalo",
+          "Butters",
+          "Cotton",
+          "Flip Flop",
+          "Inferno",
+          "Irena",
+          "Milo",
+          "Modest",
+          "Obelix",
+          "Penelope",
+          "Quincy",
+          "Sargent",
+          "Sprinkles",
+          "Toby",
+          "Trixie",
+          "Upsilon"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNTAwMjUxOSwKICAicHJvZmlsZUlkIiA6ICJiM2IyNDdhMzRkMWY0M2YzOTg2OTMyZDM0ZmViZWFlNiIsCiAgInByb2ZpbGVOYW1lIiA6ICJMYXB0eSIsCiAgInNpZ25hdHVyZVJlcXVpcmVkIiA6IHRydWUsCiAgInRleHR1cmVzIiA6IHsKICAgICJTS0lOIiA6IHsKICAgICAgInVybCIgOiAiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS9lZTEwNDhiZjlkMTA4MTZmZDQzMWMzMThiOGE2YTQ2Zjc0MDY4YjkzMzdiNTVmMDQyZjdhMTE0N2NlMmE4MGEiCiAgICB9CiAgfQp9",
+        "skull_id": "f881e61f-77ee-3369-9c45-9f6eb34f06ad",
+        "texture_id": "ee1048bf9d10816fd431c318b8a6a46f74068b9337b55f042f7a1147ce2a80a"
+      },
+      {
+        "rabbits": [
+          "Alexander",
+          "Bilbo",
+          "Buckwheat",
+          "Buster",
+          "Carter",
+          "Casper",
+          "Cloudy",
+          "Cookie",
+          "Cottonball",
+          "Demarcus",
+          "Ginger Glaze",
+          "Harmony",
+          "Honey Hazelnut",
+          "Icing Ivy",
+          "Lulu",
+          "Ozwald",
+          "Pancake",
+          "Pretzel",
+          "Raven",
+          "Squish",
+          "Stewart",
+          "Wadsworth",
+          "Xi"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNTM4NzUyNiwKICAicHJvZmlsZUlkIiA6ICJkNzU2OTc4MWUyYjY0OWIyYjVlMjVlYTJhNDZkOGQxOSIsCiAgInByb2ZpbGVOYW1lIiA6ICJEckthcGRvciIsCiAgInNpZ25hdHVyZVJlcXVpcmVkIiA6IHRydWUsCiAgInRleHR1cmVzIiA6IHsKICAgICJTS0lOIiA6IHsKICAgICAgInVybCIgOiAiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS84NDA5Yjc0ZmUxN2Q0ZTNlNDBjOGY1YTc2Y2YxMTcyODRkNTA1MWMxOTc1MWE2OTFkZGVkMDcxODU2YWZlZWM4IgogICAgfQogIH0KfQ==",
+        "skull_id": "9602333c-a3ac-3ee4-87dd-7dd3a465c0b7",
+        "texture_id": "8409b74fe17d4e3e40c8f5a76cf117284d5051c19751a691dded071856afeec8"
+      },
+      {
+        "rabbits": [
+          "Alpaca",
+          "Arachno",
+          "Bambam",
+          "Candi",
+          "Chubby",
+          "Domino",
+          "Eastwood",
+          "Ella",
+          "Fudge Fountain",
+          "Hop-a-long",
+          "Pepsi",
+          "Waffle"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNTA2MjgxMCwKICAicHJvZmlsZUlkIiA6ICI1ODc5MjNlNDkxMzM0ZDMzYWE4ZjQ3ZWJkZTljOTc3MiIsCiAgInByb2ZpbGVOYW1lIiA6ICJFbGV2ZW5mb3VyMTAiLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZTQ4OWYxMjVhNTlmMzBlNWE5ZTM4NzYxM2ZlZGY5N2EyNTFhMTNmMzhjYWEwZTFkMWE1YjVhMTM1ZDllNzhhZiIKICAgIH0KICB9Cn0=",
+        "skull_id": "8a492ce8-bf3a-3138-a7da-32fafe809b97",
+        "texture_id": "e489f125a59f30e5a9e387613fedf97a251a13f38caa0e1d1a5b5a135d9e78af"
+      },
+      {
+        "rabbits": [
+          "Ashes",
+          "Brutus",
+          "Bubbles",
+          "Chilli",
+          "Destiny",
+          "Jasmine Jello",
+          "Kobi",
+          "Maybelline",
+          "Oreo",
+          "Pillsbury",
+          "Porsche",
+          "Prestige",
+          "Snoopy"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNTM0MDE4OSwKICAicHJvZmlsZUlkIiA6ICJlZGUyYzdhMGFjNjM0MTNiYjA5ZDNmMGJlZTllYzhlYyIsCiAgInByb2ZpbGVOYW1lIiA6ICJ0aGVEZXZKYWRlIiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlL2QyZjY3NTg5ZGYzZDUzZGIwMDllNDJkNjAwZDQzNDJhNGZmMDJmYmJkMGFlMmZmOGQ5MTI4ZjQ5MjA2YzhhZmQiCiAgICB9CiAgfQp9",
+        "skull_id": "1a895dfa-657f-3f67-a975-2d1130fa71a8",
+        "texture_id": "d2f67589df3d53db009e42d600d4342a4ff02fbbd0ae2ff8d9128f49206c8afd"
+      },
+      {
+        "rabbits": [
+          "Bandit",
+          "Barcode",
+          "Charmin",
+          "Chewy",
+          "Dash",
+          "Forrest",
+          "Mediocrity",
+          "Morgan",
+          "Ringo",
+          "Una"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNTM2MzM0NCwKICAicHJvZmlsZUlkIiA6ICI0MzFhMmRlYTQ4YTE0NTMxYjEyZDU5MzY0NDUxNmIyNSIsCiAgInByb2ZpbGVOYW1lIiA6ICJpQ2FwdGFpbk5lbW8iLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMjgxMDdjNTIwMWVhMjFiYWE4OTU1MTc1MTBiMDA3ZjVmNjE1ZTNjNjYxNWRmNjk2YjkwNmFiOThlNmY5ZjA2IgogICAgfQogIH0KfQ==",
+        "skull_id": "efc542df-dac9-36ad-9017-b8c3e00767cd",
+        "texture_id": "28107c5201ea21baa895517510b007f5f615e3c6615df696b906ab98e6f9f06"
+      },
+      {
+        "rabbits": [
+          "Blueberry",
+          "Bumper",
+          "Cassidy",
+          "Gadget",
+          "Oakley",
+          "Otto",
+          "Polka Dot",
+          "Prudent",
+          "Seinfeld",
+          "Sven",
+          "Sylvester",
+          "Zombie"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNTIyMDk3NywKICAicHJvZmlsZUlkIiA6ICJkNmM2ZGYwOThiZDc0YmQzODEyMzkwZDY5MDUyNjI5MCIsCiAgInByb2ZpbGVOYW1lIiA6ICJpbmtvZ25pdG8zMzgiLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYzhlYjZmYTY3ZDJhNDcyNzdlM2MxOTVmZGU3OTRkYzdkNzY4MGVkNjgyMjc5N2IzY2I1OWM3Mzg5ZTExMDFkMCIKICAgIH0KICB9Cn0=",
+        "skull_id": "89c09392-c1af-385c-af48-4e6b0e68f084",
+        "texture_id": "c8eb6fa67d2a47277e3c195fde794dc7d7680ed6822797b3cb59c7389e1101d0"
+      }
+    ],
+    "common": [
+      {
+        "rabbits": [
+          "Aaron",
+          "Acker",
+          "Alpha",
+          "Blake",
+          "Brooks",
+          "Bruce",
+          "Bugsy",
+          "Chompsky",
+          "Cuddles",
+          "Delilah",
+          "Fluffy",
+          "Francine",
+          "Guinness",
+          "Herbie",
+          "Iggy",
+          "Jeffery",
+          "Lily",
+          "Max",
+          "Miles",
+          "Natalie",
+          "Ollie",
+          "Razzie",
+          "Rolf",
+          "Ryder",
+          "Skippe",
+          "Stanley",
+          "Woody"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNTA5OTIyMCwKICAicHJvZmlsZUlkIiA6ICJiMTM1MDRmMjMxOGI0OWNjYWFkZDcyYWVhYmMyNTQ1MCIsCiAgInByb2ZpbGVOYW1lIiA6ICJUeXBrZW4iLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjc2YTU2YzE1MWE4N2E4N2ZiMjI1NTExMGFiOThjMTA0MDgwMWJjNTdlZTJkNjUzZTRmMjg1YTEyMmM5ZjgxOCIKICAgIH0KICB9Cn0=",
+        "skull_id": "53bded4c-4a36-3b7b-a24a-6aef57fba188",
+        "texture_id": "b76a56c151a87a87fb2255110ab98c1040801bc57ee2d653e4f285a122c9f818"
+      },
+      {
+        "rabbits": [
+          "Able",
+          "Almond Amaretto",
+          "Anabelle",
+          "Archie",
+          "Badger",
+          "Baldwin",
+          "Barney",
+          "Bartholomew",
+          "Bindi",
+          "Bugster",
+          "Chip",
+          "Collin",
+          "Demi",
+          "Ember",
+          "Frank",
+          "Ginger",
+          "Hefner",
+          "Hondo",
+          "Hubby",
+          "Humphrey",
+          "Jade",
+          "Jazmin",
+          "Milly",
+          "Molly",
+          "Pinky",
+          "Reginald",
+          "Selene",
+          "Smokey",
+          "Sniffles",
+          "Snuffy",
+          "Theo"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNTAyMTEyMiwKICAicHJvZmlsZUlkIiA6ICJjMTJkMmY5ZWJhZGI0ZTllYTIxZmM2M2M3YWY3M2E5NSIsCiAgInByb2ZpbGVOYW1lIiA6ICJEcmVhbXlOZW9uIiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzZmZmEzMTE5YzA5Y2IwMTFhYjg3N2IyNzI0MWY4MjI5OTRhYWRhMzNhMjhmYTljZjgzMzFiOTE4OWJmOGFlMGMiCiAgICB9CiAgfQp9",
+        "skull_id": "3fb84d65-d866-3556-9764-78b9f5f70412",
+        "texture_id": "6ffa3119c09cb011ab877b27241f822994aada33a28fa9cf8331b9189bf8ae0c"
+      },
+      {
+        "rabbits": [
+          "Alfie",
+          "Angus",
+          "Arnie",
+          "Baby",
+          "Basket",
+          "Baxter",
+          "Bibsy",
+          "Binky",
+          "Brian",
+          "Bud",
+          "Crush",
+          "Digger",
+          "Frankie",
+          "Gizmo",
+          "Gloria",
+          "Gouda",
+          "Heidie",
+          "Hopper",
+          "Indie",
+          "Jake",
+          "Jasmine",
+          "Joey",
+          "Jonah",
+          "Mickey",
+          "Moody",
+          "Nu",
+          "Paddy",
+          "Pebbles",
+          "Porter",
+          "Stinky",
+          "Tagalong",
+          "Theodore",
+          "William",
+          "Zea"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNTE1ODczOSwKICAicHJvZmlsZUlkIiA6ICI2YzdjZWFjNTdjM2Q0ZTdmYWI3MTc3YTRkMDhlMGU2MSIsCiAgInByb2ZpbGVOYW1lIiA6ICJNRzE0MSIsCiAgInNpZ25hdHVyZVJlcXVpcmVkIiA6IHRydWUsCiAgInRleHR1cmVzIiA6IHsKICAgICJTS0lOIiA6IHsKICAgICAgInVybCIgOiAiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS9jN2MyODJhZDU4NjE2ZjkyZDhiYmE3OTk5ZWY0OWYyODViOTlkYWY3OGM1NTM0NWMyNzZlNDRkN2Q2NjIyYzk3IgogICAgfQogIH0KfQ==",
+        "skull_id": "6aa92d06-f863-37bc-9d7e-8d8dcde76208",
+        "texture_id": "c7c282ad58616f92d8bba7999ef49f285b99daf78c55345c276e44d7d6622c97"
+      },
+      {
+        "rabbits": [
+          "Alice",
+          "Bagel",
+          "Beatrice",
+          "Bertha",
+          "Cave",
+          "Chester",
+          "Cricket",
+          "Delboy",
+          "Dusty",
+          "Fergie",
+          "Fievel",
+          "Fudge",
+          "George",
+          "Ginny",
+          "Harley",
+          "Jammer",
+          "Jerry",
+          "Josephine",
+          "Mandy",
+          "Maui",
+          "Nibbles",
+          "Oletta",
+          "Olivette",
+          "Quentin",
+          "Remi",
+          "Ross",
+          "Ruben",
+          "Rupert",
+          "Scout",
+          "Snoppy",
+          "Stuart",
+          "Ticky",
+          "Webb",
+          "Zack"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNTExNDE5OCwKICAicHJvZmlsZUlkIiA6ICI5ZDE1OGM1YjNiN2U0ZGNlOWU0OTA5MTdjNmJlYmM5MSIsCiAgInByb2ZpbGVOYW1lIiA6ICJTbm9uX1NTIiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzE1ZDBmMGMzNjhlNTRkMjBlM2M1ZTU1MGEwNGE0NjlkMDE2MWIxZmVjZjI2YzhlNTE4MzE4YzA5ZTExMzRmNmIiCiAgICB9CiAgfQp9",
+        "skull_id": "12cfcf5a-aaf8-3a88-ab5a-bacb8557f002",
+        "texture_id": "15d0f0c368e54d20e3c5e550a04a469d0161b1fecf26c8e518318c09e1134f6b"
+      },
+      {
+        "rabbits": [
+          "Audi",
+          "Bramble",
+          "Buttercream Blossom",
+          "Chomper",
+          "Copper",
+          "Cottontail",
+          "Duchess",
+          "Emerson",
+          "Espresso Eclair",
+          "Fuzzy",
+          "Hadley",
+          "Hugo",
+          "Hunter",
+          "James",
+          "Lenny",
+          "Marlow",
+          "Morris",
+          "Olivier",
+          "Poppy",
+          "Ricky",
+          "Rosco",
+          "Sassy",
+          "Scuba",
+          "Sophie",
+          "Sorbet",
+          "Spot",
+          "Teddy",
+          "Thailai",
+          "Tobi",
+          "Winston"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNTEzNzMxMiwKICAicHJvZmlsZUlkIiA6ICJhNDAxZjEzMTZlMjI0ZTNjOTg0ODk1MmVjMzhjMTEwYyIsCiAgInByb2ZpbGVOYW1lIiA6ICJHcmVlbnNoZWVwaXJhdGUiLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjFiOTNkNGU3OTJiYmYxNTIyOTE1YjRjNWYwNDQ0NjU5ZmEzNjE0YzQ1YTJiMjkyMmU2MWE4ODhlNjFjNzE0ZSIKICAgIH0KICB9Cn0=",
+        "skull_id": "4166e69c-e158-3fe8-9b96-7ed612af6f5d",
+        "texture_id": "b1b93d4e792bbf1522915b4c5f0444659fa3614c45a2b2922e61a888e61c714e"
+      },
+      {
+        "rabbits": [
+          "Augustus",
+          "Baloo",
+          "Billy",
+          "Bruno",
+          "Cadet",
+          "Chase",
+          "Claude",
+          "Cocoa Comet",
+          "Dulce Drizzle",
+          "Ellie",
+          "Eta",
+          "Gracie",
+          "Mimi",
+          "Mochi",
+          "Mona",
+          "Nutmeg",
+          "Oliver",
+          "Patch",
+          "Penny",
+          "Peony",
+          "Petunia",
+          "Picky",
+          "Ressie",
+          "Rowdy",
+          "Scooter",
+          "Scotch",
+          "Spencer",
+          "Suri",
+          "Tau"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNTA4MTAyNywKICAicHJvZmlsZUlkIiA6ICJkN2JjNjA0MDRlNjg0MjM2OTVhODk0ZjNjZjM5MjVmNCIsCiAgInByb2ZpbGVOYW1lIiA6ICJfQ3liZXJEZW1vbl8iLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMTM3ZjZiZDVlN2M0ZThmYjIyYzg4ZWIwOTUzNzA3OWJkM2Q0YzE0NGNmNWEzNzZjZTZmMjAzMDExMGJkMTY4MCIKICAgIH0KICB9Cn0=",
+        "skull_id": "260c1a15-405c-34a0-b9c9-e47ee987d6ab",
+        "texture_id": "137f6bd5e7c4e8fb22c88eb09537079bd3d4c144cf5a376ce6f2030110bd1680"
+      },
+      {
+        "rabbits": [
+          "Bob",
+          "Breeze",
+          "Brie",
+          "Bronson",
+          "Callie",
+          "Cupcake",
+          "Gunther",
+          "Hershey",
+          "Huck",
+          "Lone Ranger",
+          "Lotte",
+          "Louie",
+          "Mookie",
+          "Mopsy",
+          "Ned",
+          "Niko",
+          "Niza",
+          "Pickles",
+          "Riley",
+          "Thumper"
+        ],
+        "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNTE3Nzk1MCwKICAicHJvZmlsZUlkIiA6ICI3ZjU2ZjY1MDI2NjY0ZmM1OWFjNWYyYjVjMTNlZGY3NyIsCiAgInByb2ZpbGVOYW1lIiA6ICJNYXhBbnRvbnkiLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNmIzOGZhMGE2MjExMzUzOWIxOGZjMzFkMWUwNGJlMzRkNDdiN2Q1MDBlZjc5MGI1M2Y4M2Q4MWM0NzllZDI5ZCIKICAgIH0KICB9Cn0",
+        "skull_id": "c066dd69-4083-3ebe-aa9f-b69e280cb929",
+        "texture_id": "6b38fa0a62113539b18fc31d1e04be34d47b7d500ef790b53f83d81c479ed29d"
+      }
+    ]
+  }
+}

--- a/constants/HoppityRabbitTextures.json
+++ b/constants/HoppityRabbitTextures.json
@@ -196,6 +196,7 @@
       {
         "rabbits": [
           "Ace",
+          "Krys",
           "Quince Quark",
           "Thor"
         ],
@@ -206,6 +207,7 @@
       {
         "rabbits": [
           "Achilles",
+          "Eisen",
           "Kappa"
         ],
         "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNDkzMDc1NCwKICAicHJvZmlsZUlkIiA6ICI2NGRiNmMwNTliOTk0OTM2YTY0M2QwODEwODE0ZmJkMyIsCiAgInByb2ZpbGVOYW1lIiA6ICJUaGVTaWx2ZXJEcmVhbXMiLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMTg5ODkxNjRkZmM2MDQ3YjQ3ZjRkNjlmMGZmMjM4NmE0YmJhNGUxYjA4ZWE3NmIzNzc3N2JkMDhiOWMxZjVjOSIKICAgIH0KICB9Cn0=",
@@ -229,10 +231,12 @@
         "rabbits": [
           "Angel",
           "Comet",
+          "Maxima",
           "Necron",
           "Peppermint Pearl",
           "Toffee Tulip",
-          "Trix"
+          "Trix",
+          "Violet"
         ],
         "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNDg2ODU1OCwKICAicHJvZmlsZUlkIiA6ICIyMWNjMzkxZmNkMjc0NzY5OTg5Y2M3M2VjYWRiNTE3YiIsCiAgInByb2ZpbGVOYW1lIiA6ICJHT1NUTFk5NyIsCiAgInNpZ25hdHVyZVJlcXVpcmVkIiA6IHRydWUsCiAgInRleHR1cmVzIiA6IHsKICAgICJTS0lOIiA6IHsKICAgICAgInVybCIgOiAiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS9lMWIwMzUzYWVhMzdkYzQ1MTRkZGYxZjY0MWY1ZTRjZDIwMjhkN2FmODU4NGZhNGM2ZWE1YjA5ZmQ0ODliZGEwIgogICAgfQogIH0KfQ==",
         "skull_id": "585c3f61-915b-3a51-a4f5-22043510bb9c",
@@ -241,9 +245,11 @@
       {
         "rabbits": [
           "Calypso",
+          "Castle",
           "Kiera",
           "Prince",
-          "Punch"
+          "Punch",
+          "Rochie"
         ],
         "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNDg1MTg3NSwKICAicHJvZmlsZUlkIiA6ICJkZTU3MWExMDJjYjg0ODgwOGZlN2M5ZjQ0OTZlY2RhZCIsCiAgInByb2ZpbGVOYW1lIiA6ICJNSEZfTWluZXNraW4iLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNzdiY2Q2YTAwZjgxNGIyNWQ2YjI1ZTFhMmI3YzhkN2NjOWY3N2NlZmM2ZjBjMWJhM2Q1OWVkOGRiYWIyMjY3NSIKICAgIH0KICB9Cn0=",
         "skull_id": "407f7b1a-d0a8-31c3-8cf8-e60bbddab1f1",
@@ -252,6 +258,7 @@
       {
         "rabbits": [
           "Delta",
+          "Hole",
           "Ken",
           "Kodo",
           "Merlin",
@@ -284,8 +291,10 @@
           "Draco",
           "Elvis",
           "Gamma",
+          "Gravler",
           "Gremlin",
           "Jynx",
+          "Mush Mush",
           "Phantom",
           "Snowball"
         ],
@@ -304,6 +313,7 @@
           "Orange Obsidian",
           "Pride",
           "Spooky",
+          "Sulfur",
           "Sunny",
           "Widget"
         ],
@@ -332,7 +342,9 @@
       {
         "rabbits": [
           "Bishop",
+          "Egg",
           "Iota",
+          "Kalumdai",
           "Murphy",
           "Neptune",
           "Omicron",
@@ -374,6 +386,8 @@
       },
       {
         "rabbits": [
+          "Canopus",
+          "Carmine",
           "Crystal",
           "Favor",
           "Frodo",
@@ -425,6 +439,7 @@
           "Dandelion",
           "Darla",
           "Demetrious",
+          "Ender",
           "Fitch",
           "Gee-Gee",
           "Goofy",
@@ -500,6 +515,7 @@
         "rabbits": [
           "Alpaca",
           "Arachno",
+          "Attila",
           "Bambam",
           "Candi",
           "Chubby",
@@ -544,8 +560,10 @@
           "Dash",
           "Forrest",
           "Mediocrity",
+          "Melon",
           "Morgan",
           "Ringo",
+          "Ruina",
           "Una"
         ],
         "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNTM2MzM0NCwKICAicHJvZmlsZUlkIiA6ICI0MzFhMmRlYTQ4YTE0NTMxYjEyZDU5MzY0NDUxNmIyNSIsCiAgInByb2ZpbGVOYW1lIiA6ICJpQ2FwdGFpbk5lbW8iLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMjgxMDdjNTIwMWVhMjFiYWE4OTU1MTc1MTBiMDA3ZjVmNjE1ZTNjNjYxNWRmNjk2YjkwNmFiOThlNmY5ZjA2IgogICAgfQogIH0KfQ==",
@@ -597,6 +615,7 @@
           "Natalie",
           "Ollie",
           "Razzie",
+          "Rogue",
           "Rolf",
           "Ryder",
           "Skippe",
@@ -625,6 +644,7 @@
           "Ember",
           "Frank",
           "Ginger",
+          "Harland",
           "Hefner",
           "Hondo",
           "Hubby",
@@ -633,7 +653,9 @@
           "Jazmin",
           "Milly",
           "Molly",
+          "Morty",
           "Pinky",
+          "Potato",
           "Reginald",
           "Selene",
           "Smokey",
@@ -688,10 +710,12 @@
       },
       {
         "rabbits": [
+          "Albus",
           "Alice",
           "Bagel",
           "Beatrice",
           "Bertha",
+          "Carrot",
           "Cave",
           "Chester",
           "Cricket",
@@ -811,9 +835,11 @@
           "Gunther",
           "Hershey",
           "Huck",
+          "Lazy",
           "Lone Ranger",
           "Lotte",
           "Louie",
+          "Mite",
           "Mookie",
           "Mopsy",
           "Ned",
@@ -821,6 +847,7 @@
           "Niza",
           "Pickles",
           "Riley",
+          "Soon",
           "Thumper"
         ],
         "texture_value_b64": "ewogICJ0aW1lc3RhbXAiIDogMTcxMTYzNTE3Nzk1MCwKICAicHJvZmlsZUlkIiA6ICI3ZjU2ZjY1MDI2NjY0ZmM1OWFjNWYyYjVjMTNlZGY3NyIsCiAgInByb2ZpbGVOYW1lIiA6ICJNYXhBbnRvbnkiLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNmIzOGZhMGE2MjExMzUzOWIxOGZjMzFkMWUwNGJlMzRkNDdiN2Q1MDBlZjc5MGI1M2Y4M2Q4MWM0NzllZDI5ZCIKICAgIH0KICB9Cn0",


### PR DESCRIPTION
Adds data so that we can perform lookup from Skull ID -> Rabbit Rarity, and can also lookup Rabbit Name -> Skin/Texture ID.

Omega, Psi, and Chi are missing from this list, but milestone rabbits shouldn't be strictly necessary yet, and can get added as people get them.