### PR TITLE
Clarify Mana Ray rate

### DIFF
--- a/constants/TrophyFish.json
+++ b/constants/TrophyFish.json
@@ -112,8 +112,8 @@
     },
     "manaray": {
       "displayName": "§9Mana Ray",
-      "description": "§7Caught when you have at least §b1200 ✎ Mana§7.",
-      "rate": 4,
+      "description": "§7Caught when you have at least §b1200 ✎ Mana§7. The catch chance is your §b✎ Mana§7 divided by 1000 (e.g. 1.2% at §b1200 ✎ Mana§7).",
+      "rate": null,
       "fillet": {
         "bronze": 40,
         "silver": 60,


### PR DESCRIPTION
Removed hardcoded rate and added a note about how it is calculated.

We can still make SkyHanni show the exact rate for the player based on their mana later, but this is a start.