### PR TITLE
Add numbers to Argofay Threebrothers

### DIFF
--- a/constants/island_graphs/THE_RIFT.json
+++ b/constants/island_graphs/THE_RIFT.json
@@ -5801,7 +5801,7 @@
   },
   "673": {
     "Position": "-135.0:76.0:113.0",
-    "Name": "Argofay Threebrother",
+    "Name": "Argofay Threebrother #1",
     "Tags": [
       "npc"
     ],
@@ -6412,7 +6412,7 @@
   },
   "753": {
     "Position": "-100.0:77.0:152.0",
-    "Name": "Argofay Threebrother",
+    "Name": "Argofay Threebrother #2",
     "Tags": [
       "npc",
       "dev"
@@ -11071,7 +11071,7 @@
   },
   "1337": {
     "Position": "-92.0:77.0:108.0",
-    "Name": "Argofay Threebrother",
+    "Name": "Argofay Threebrother #3",
     "Tags": [
       "dev",
       "npc"


### PR DESCRIPTION
If they have the same name, `/shnavigate` only shows the closest one, which is bad for initial completion of the quest, because you specifically have to talk to all three of them (in any order) to obtain the Wyld Sword.

After the initial quest completion, any one of them will let you buy the sword again, but this is important for the initial quest.