### PR TITLE
Add new book bundle amounts

### DIFF
--- a/constants/Items.json
+++ b/constants/Items.json
@@ -53,12 +53,15 @@
     "infinite_quiver": 0.03
   },
   "book_bundle_amount": {
-    "vicious": 5,
     "big_brain": 5,
-    "reflection": 3,
+    "pristine": 5,
     "quantum": 1,
+    "rainbow": 1,
+    "reflection": 3,
+    "small_brain": 1,
+    "ultimate_chimera": 1,
     "ultimate_the_one": 1,
-    "rainbow": 1
+    "vicious": 5
   },
   "value_calculation_data": {
     "always_active_enchants": {

--- a/constants/Items.json
+++ b/constants/Items.json
@@ -54,7 +54,7 @@
   },
   "book_bundle_amount": {
     "big_brain": 5,
-    "pristine": 5,
+    "pristine": 1,
     "quantum": 1,
     "rainbow": 1,
     "reflection": 3,


### PR DESCRIPTION
Added Chimera, Prismatic, and Small Brain. Also alphabetized the list.

This still needs further fixes in SkyHanni for Chimera (because it will likely say 1x Chimera I instead of 1x Chimera V), and we'll probably also update it to read the amount from the lore, but I think this is the best we can do in the repo for now.