### PR TITLE
Update Magma Lord Armor Attributes and add support for Magma Lord Gauntlet

### DIFF
--- a/constants/AttributeGoodRolls.json
+++ b/constants/AttributeGoodRolls.json
@@ -89,7 +89,7 @@
       ]
     },
     "Magma Lord Armor": {
-      "regex": "MAGMA_LORD_(?:HELMET|CHESTPLATE|LEGGINGS|BOOTS)",
+      "regex": "MAGMA_LORD_(?:HELMET|CHESTPLATE|LEGGINGS|BOOTS|GAUNTLET)",
       "list": [
         [
           "fishing_experience",
@@ -106,6 +106,10 @@
         [
           "mana_pool",
           "fishing_experience"
+        ],
+        [
+          "mana_pool",
+          "mana_regeneration"
         ]
       ]
     },

--- a/constants/AttributeGoodRolls.json
+++ b/constants/AttributeGoodRolls.json
@@ -89,7 +89,7 @@
       ]
     },
     "Magma Lord Armor": {
-      "regex": "MAGMA_LORD_(?:HELMET|CHESTPLATE|LEGGINGS|BOOTS|GAUNTLET)",
+      "regex": "MAGMA_LORD_(?:HELMET|CHESTPLATE|LEGGINGS|BOOTS)",
       "list": [
         [
           "fishing_experience",
@@ -110,6 +110,31 @@
         [
           "mana_pool",
           "mana_regeneration"
+        ]
+      ]
+    },
+    "Magma Lord Gauntlet": {
+      "regex": "MAGMA_LORD_GAUNTLET",
+      "list": [
+        [
+          "fishing_experience",
+          "blazing_fortune"
+        ],
+        [
+          "fishing_experience",
+          "magic_find"
+        ],
+        [
+          "blazing_fortune",
+          "magic_find"
+        ],
+        [
+          "mana_pool",
+          "fishing_experience"
+        ],
+        [
+          "lifeline",
+          "mana_pool"
         ]
       ]
     },


### PR DESCRIPTION
Adds support for Magma Lord Gauntlet and adds MP MR as a good roll for Magma Lord Armor (helpful for killing jawbus apparently).