### PR TITLE
Adding golden bait to fishing profit tracker

### DIFF
--- a/constants/FishingProfitItems.json
+++ b/constants/FishingProfitItems.json
@@ -24,7 +24,8 @@
       "DYE_AQUAMARINE",
       "SULPHUR_ORE",
       "CORRUPTED_FRAGMENT",
-      "DYE_FLAME"
+      "DYE_FLAME",
+      "GOLDEN_BAIT"
     ],
     "Water": [
       "FAIRY_HELMET",


### PR DESCRIPTION
The golden bait was added with Year of the seal update. It can also be caught in treasure catches. It hasn't been added to the tracker, so this change will add that