### PR TITLE
hide missing rod part category error

### DIFF
--- a/constants/ChangedChatErrors.json
+++ b/constants/ChangedChatErrors.json
@@ -103,6 +103,12 @@
         "TPS calculation got an error"
       ],
       "fixed_in": "1.12.0"
+    },
+    {
+      "message_starts_with": [
+        "Could not read category for item"
+      ],
+      "fixed_in": "2.99.0"
     }
   ]
 }

--- a/constants/ChangedChatErrors.json
+++ b/constants/ChangedChatErrors.json
@@ -108,7 +108,7 @@
       "message_starts_with": [
         "Could not read category for item"
       ],
-      "fixed_in": "2.99.0"
+      "fixed_in": "2.1.0"
     }
   ]
 }


### PR DESCRIPTION
the new fishing update has a new item category

doesn't affect 2.0 right now since it's not a beta version, but everyone that hasn't updated yet should have this issue on the alpha network