### PR TITLE
Revert "hide missing rod part category error (#352)"

### DIFF
--- a/constants/ChangedChatErrors.json
+++ b/constants/ChangedChatErrors.json
@@ -103,12 +103,6 @@
         "TPS calculation got an error"
       ],
       "fixed_in": "1.12.0"
-    },
-    {
-      "message_starts_with": [
-        "Could not read category for item"
-      ],
-      "fixed_in": "2.1.0"
     }
   ]
 }


### PR DESCRIPTION
This reverts commit a8490d2dcf34faf8caaa05de4f00f6e3db371303.

Not needed as itemcategory gets fixed via a repo pattern. bda7e6a71f03abc2a7ca3ac37d895962787deed4