### PR TITLE
Fix Tabasco good level

### DIFF
--- a/constants/Enchants.json
+++ b/constants/Enchants.json
@@ -525,7 +525,7 @@
     "tabasco": {
       "loreName": "Tabasco",
       "nbtName": "tabasco",
-      "goodLevel": 0,
+      "goodLevel": 1,
       "maxLevel": 3
     },
     "thorns": {


### PR DESCRIPTION
Doesn't change anything for most people, but this makes the glitched and now unobtainable Tabasco I "good" (blue) instead of "great" (gold). Can't make it "bad" (gray) with our current structure so this will do.

This is consistent with how we set the good level for other enchants where the lowest level is higher than 1.