### PR TITLE
Remove old fishing rods

### DIFF
--- a/constants/Items.json
+++ b/constants/Items.json
@@ -43,22 +43,11 @@
   ],
   "water_fishing_rods": [
     "FISHING_ROD",
-    "PRISMARINE_ROD",
-    "ICE_ROD",
-    "SPONGE_ROD",
-    "SPEEDSTER_ROD",
-    "FARMER_ROD",
-    "WINTER_ROD",
     "CHALLENGE_ROD",
     "CHAMP_ROD",
     "LEGEND_ROD",
     "ROD_OF_THE_SEA",
-    "YETI_ROD",
-    "AUGER_ROD",
-    "CHUM_ROD",
-    "GIANT_FISHING_ROD",
-    "THE_SHREDDER",
-    "PHANTOM_ROD"
+    "GIANT_FISHING_ROD"
   ],
   "dungeon_secret_items": [
     "DEFUSE_KIT",


### PR DESCRIPTION
These rods can no longer be used to fish, but people may use them for autopet to swap pets without actually casting a fishing hook.