### PR TITLE
Added "new" fishing items from bayou to fishingprofititems.json

### DIFF
--- a/constants/FishingProfitItems.json
+++ b/constants/FishingProfitItems.json
@@ -116,6 +116,7 @@
       "FLYING_FISH;4",
       "BLESSING;6",
       "THE_SHREDDER",
+      "SHREDDED_LINE",
       "CHUM",
       "SQUID;0",
       "SQUID;1",

--- a/constants/FishingProfitItems.json
+++ b/constants/FishingProfitItems.json
@@ -233,6 +233,7 @@
       "ENCHANTED_PACKED_ICE",
       "WHITE_GIFT",
       "ICE_ROD",
+      "ICY_SINKER",
       "SNOW_BLOCK",
       "CARROT_ITEM",
       "RED_GIFT",
@@ -254,6 +255,7 @@
       "WEREWOLF_SKIN",
       "DEEP_SEA_ORB",
       "PHANTOM_ROD",
+      "PHANTOM_HOOK",
       "SOUL_FRAGMENT",
       "PET_ITEM_VAMPIRE_FANG"
     ],


### PR DESCRIPTION
I assume the old items should stay so they're still present in people's profit trackers but idk this was missed when updating for Bayou and I'm probably missing something.