### PR TITLE
Update Frail max level

### DIFF
--- a/constants/Enchants.json
+++ b/constants/Enchants.json
@@ -190,7 +190,7 @@
       "loreName": "Frail",
       "nbtName": "frail",
       "goodLevel": 5,
-      "maxLevel": 6
+      "maxLevel": 7
     },
     "frost walker": {
       "loreName": "Frost Walker",


### PR DESCRIPTION
The "Severed Pincer" item was added in Bayou update to increase frail from level 6 to 7
