### PR TITLE
Disable garden keybinds on 1.21

### DIFF
--- a/constants/misc/EnforcedConfigValues.json
+++ b/constants/misc/EnforcedConfigValues.json
@@ -1,25 +1,15 @@
 {
     "enforced_config_values": [
         {
-            "chatPSA": [
-                "§cWe have disabled the real time show seconds option due to time zones being more confusing than first thought",
-                "Supports multiple lines!!"
-            ],
-            "notificationPSA": [
-                "§cWARNING: this is a warning but its in a notification popup",
-                "Also supports multiple lines!!"
-            ],
             "enforcedValues": [
                 {
-                    "path": "gui.realTimeShowSeconds",
+                    "path": "garden.keyBind.enabled",
                     "value": false
                 }
             ],
-            "affectedVersion": "1.2.0",
+            "affectedVersion": "4.0.0",
             "affectedMinecraftVersions": [
-                "1.8.9",
-                "1.7.10",
-                "1.12.2"
+                "1.21.5"
             ]
         }
     ]


### PR DESCRIPTION
1. I dont think the feature fully works on 1.21 rn
2. Someone crashed and crash is bad