### PR TITLE
Update good rolls based on Ananke Feathers

### DIFF
--- a/constants/AttributeGoodRolls.json
+++ b/constants/AttributeGoodRolls.json
@@ -1,44 +1,16 @@
 {
   "good_rolls": {
     "Aurora Armor": {
-      "regex": "(?:(?:HOT|BURNING|FIERY|INFERNAL)_)?AURORA_(?:HELMET|CHESTPLATE|LEGGINGS|BOOTS)",
+      "regex": "(?:(?:HOT|BURNING|FIERY|INFERNAL)_)?AURORA_(?:CHESTPLATE|LEGGINGS|BOOTS)",
       "list": [
         [
           "mana_regeneration",
           "mana_pool"
-        ],
-        [
-          "breeze",
-          "mana_pool"
-        ],
-        [
-          "veteran",
-          "breeze"
-        ],
-        [
-          "mana_pool",
-          "mending"
-        ],
-        [
-          "mana_regeneration",
-          "mending"
-        ],
-        [
-          "mana_pool",
-          "magic_find"
-        ],
-        [
-          "mana_regeneration",
-          "magic_find"
-        ],
-        [
-          "mana_pool",
-          "undead_resistance"
         ]
       ]
     },
     "Crimson Armor": {
-      "regex": "(?:(?:HOT|BURNING|FIERY|INFERNAL)_)?CRIMSON_(?:HELMET|CHESTPLATE|LEGGINGS|BOOTS)",
+      "regex": "(?:(?:HOT|BURNING|FIERY|INFERNAL)_)?CRIMSON_(?:CHESTPLATE|LEGGINGS|BOOTS)",
       "list": [
         [
           "veteran",
@@ -54,37 +26,19 @@
         ]
       ]
     },
-    "Terror Armor": {
-      "regex": "(?:(?:HOT|BURNING|FIERY|INFERNAL)_)?TERROR_(?:HELMET|CHESTPLATE|LEGGINGS|BOOTS)",
+    "Crimson Helmet": {
+      "regex": "(?:(?:HOT|BURNING|FIERY|INFERNAL)_)?CRIMSON_HELMET",
       "list": [
-        [
-          "mana_pool",
-          "dominance"
-        ],
-        [
-          "dominance",
-          "lifeline"
-        ],
-        [
-          "mana_pool",
-          "lifeline"
-        ],
-        [
-          "mana_pool",
-          "mana_regeneration"
-	]
+        "veteran",
+        "magic_find"
       ]
     },
-    "Lava Sea Creature Armor": {
-      "regex": "SLUG_BOOTS|TAURUS_HELMET|FLAMING_CHESTPLATE|MOOGMA_LEGGINGS",
+    "Terror Armor": {
+      "regex": "(?:(?:HOT|BURNING|FIERY|INFERNAL)_)?TERROR_(?:CHESTPLATE|LEGGINGS|BOOTS)",
       "list": [
         [
-          "fishing_experience",
-          "blazing_fortune"
-        ],
-        [
-          "blazing_fortune",
-          "magic_find"
+          "mana_pool",
+          "lifeline"
         ]
       ]
     },
@@ -102,14 +56,6 @@
         [
           "blazing_fortune",
           "magic_find"
-        ],
-        [
-          "mana_pool",
-          "fishing_experience"
-        ],
-        [
-          "mana_pool",
-          "mana_regeneration"
         ]
       ]
     },
@@ -121,37 +67,12 @@
           "blazing_fortune"
         ],
         [
-          "fishing_experience",
-          "magic_find"
-        ],
-        [
           "blazing_fortune",
           "magic_find"
         ],
         [
-          "mana_pool",
-          "fishing_experience"
-        ],
-        [
           "lifeline",
           "mana_pool"
-        ]
-      ]
-    },
-    "Lava Rods": {
-      "regex": "(?:MAGMA|INFERNO|HELLFIRE)_ROD",
-      "list": [
-        [
-          "fishing_speed",
-          "double_hook"
-        ],
-        [
-          "fishing_speed",
-          "trophy_hunter"
-        ],
-        [
-          "trophy_hunter",
-          "fisherman"
         ]
       ]
     },
@@ -188,24 +109,12 @@
         [
           "mana_regeneration",
           "mana_pool"
-        ],
-        [
-          "dominance",
-          "mana_pool"
-        ],
-        [
-          "mana_pool",
-          "veteran"
         ]
       ]
     },
     "Gauntlet Of Contagion": {
       "regex": "GAUNTLET_OF_CONTAGION",
       "list": [
-        [
-          "veteran",
-          "breeze"
-        ],
         [
           "mana_pool",
           "lifeline"
@@ -224,7 +133,7 @@
         ],
         [
           "veteran",
-          "mana_pool"
+          "mending"
         ]
       ]
     },
@@ -238,14 +147,6 @@
         [
           "lifeline",
           "mana_pool"
-        ],
-        [
-          "magic_find",
-          "mending"
-        ],
-        [
-          "dominance",
-          "speed"
         ]
       ]
     },
@@ -259,14 +160,6 @@
         [
           "lifeline",
           "mana_pool"
-        ],
-        [
-          "magic_find",
-          "mending"
-        ],
-        [
-          "dominance",
-          "speed"
         ]
       ]
     },
@@ -282,14 +175,6 @@
           "mana_pool"
         ],
         [
-          "magic_find",
-          "mending"
-        ],
-        [
-          "breeze",
-          "mana_pool"
-        ],
-        [
           "mana_regeneration",
           "mana_pool"
         ]
@@ -299,20 +184,12 @@
       "regex": "MOLTEN_NECKLACE",
       "list": [
         [
-          "dominance",
-          "speed"
-        ],
-        [
           "mana_pool",
           "mana_regeneration"
         ],
         [
           "dominance",
           "mana_pool"
-        ],
-        [
-          "veteran",
-          "breeze"
         ]
       ]
     },
@@ -337,58 +214,8 @@
       "regex": "(?:VANQUISHED_)?GHAST_CLOAK",
       "list": [
         [
-          "dominance",
-          "mana_pool"
-        ],
-        [
           "veteran",
           "mending"
-        ],
-        [
-          "mana_pool",
-          "mana_regeneration"
-        ],
-        [
-          "lifeline",
-          "mana_pool"
-        ]
-      ]
-    },
-    "Blaze Belt": {
-      "regex": "(?:VANQUISHED_)?BLAZE_BELT",
-      "list": [
-        [
-          "dominance",
-          "mana_pool"
-        ],
-        [
-          "veteran",
-          "mending"
-        ],
-        [
-          "lifeline",
-          "mana_pool"
-        ]
-      ]
-    },
-    "Glowstone Gauntlet": {
-      "regex": "(?:VANQUISHED_)?GLOWSTONE_GAUNTLET",
-      "list": [
-        [
-          "dominance",
-          "mana_pool"
-        ],
-        [
-          "veteran",
-          "mending"
-        ],
-        [
-          "mana_pool",
-          "mana_regeneration"
-        ],
-        [
-          "lifeline",
-          "mana_pool"
         ]
       ]
     }

--- a/constants/AttributeGoodRolls.json
+++ b/constants/AttributeGoodRolls.json
@@ -9,6 +9,13 @@
         ]
       ]
     },
+    "Crimson Helmet": {
+      "regex": "(?:(?:HOT|BURNING|FIERY|INFERNAL)_)?CRIMSON_HELMET",
+      "list": [
+        "veteran",
+        "magic_find"
+      ]
+    },
     "Crimson Armor": {
       "regex": "(?:(?:HOT|BURNING|FIERY|INFERNAL)_)?CRIMSON_(?:CHESTPLATE|LEGGINGS|BOOTS)",
       "list": [
@@ -24,13 +31,6 @@
           "veteran",
           "magic_find"
         ]
-      ]
-    },
-    "Crimson Helmet": {
-      "regex": "(?:(?:HOT|BURNING|FIERY|INFERNAL)_)?CRIMSON_HELMET",
-      "list": [
-        "veteran",
-        "magic_find"
       ]
     },
     "Terror Armor": {


### PR DESCRIPTION
Updated "Good Rolls" list to only highlight legacy attribute combinations on items that grant [Ananke Feathers](https://wiki.hypixel.net/Ananke_Feather), since the rest are pretty much worthless now.

Players can still manually select other attributes they may be interested in for salvaging just for the shards.