### PR TITLE
Add non Slayer Drop but Slayer related shards.

### DIFF
--- a/constants/SlayerProfitTrackerItems.json
+++ b/constants/SlayerProfitTrackerItems.json
@@ -21,6 +21,8 @@
       "GHOUL;4",
       "DYE_MATCHA",
       "ATTRIBUTE_SHARD_UNDEAD_ESSENCE;1",
+      "ATTRIBUTE_SHARD_LIFE_RECOVERY;1",
+      "ATTRIBUTE_SHARD_MIDAS_TOUCH;1",
       "FESTERING_MAGGOT"
     ],
     "Tarantula Broodfather": [
@@ -47,6 +49,8 @@
       "ENSNARED_SNAIL",
       "SHRIVELED_WASP",
       "TARANTULA_SILK",
+      "ATTRIBUTE_SHARD_ARACHNO;1",
+      "ATTRIBUTE_SHARD_ARACHNO_RESISTANCE;1",
       "DYE_BRICK_RED"
     ],
     "Sven Packmaster": [
@@ -96,7 +100,8 @@
       "ENDERMAN;2",
       "ENDERMAN;3",
       "ENDERMAN;4",
-      "DYE_BYZANTIUM"
+      "DYE_BYZANTIUM",
+      "ATTRIBUTE_SHARD_ENDER;1"
     ],
     "Inferno Demonlord": [
       "DERELICT_ASHE",
@@ -127,7 +132,8 @@
       "MILLENIA_OLD_BLAZE_ASHES",
       "SMOLDERING;1",
       "SWORD_OF_BAD_HEALTH",
-      "DYE_FLAME"
+      "DYE_FLAME",
+      "ATTRIBUTE_SHARD_ATTACK_SPEED;1"
     ],
     "Riftstalker Bloodfiend": [
       "COVEN_SEAL",


### PR DESCRIPTION
Adds Voracious Spider and Flaming Spider shards to Spider Slayer Profit Tracker
adds Bruiser shard to Voidgloom Slayer Profit Tracker
adds Golden Ghoul and Sycophant (Miniboss) Shards to Revenant Profit Tracker
Adds burning soul (red miniboss from T3+) to Blaze Profit Tracker