### PR TITLE
Update SlayerProfitTrackerItems.json

### DIFF
--- a/constants/SlayerProfitTrackerItems.json
+++ b/constants/SlayerProfitTrackerItems.json
@@ -108,7 +108,7 @@
       "DYE_BYZANTIUM",
       "ATTRIBUTE_SHARD_ENDER;1",
       "ATTRIBUTE_SHARD_ENDER_RESISTANCE;1",
-      "ENDSTONE_IDL"
+      "ENDSTONE_IDOL"
     ],
     "Inferno Demonlord": [
       "DERELICT_ASHE",


### PR DESCRIPTION
Added ES7 and Smite 7 replacements
they should PROBABLY be config fixed or something in the actual mod to their new equivalents but god knows I'm not skilled enough for that, leaving them here because they shouldn't even drop anymore