### PR TITLE
Unmark Ent as rare

### DIFF
--- a/constants/SeaCreatures.json
+++ b/constants/SeaCreatures.json
@@ -452,8 +452,7 @@
       "Ent": {
         "chat_message": "§aYou've hooked an Ent, as ancient as the forest itself.",
         "fishing_experience": 0,
-        "rarity": "EPIC",
-        "rare": true
+        "rarity": "EPIC"
       },
       "Tadgang": {
         "chat_message": "§aA gang of Liltads!",


### PR DESCRIPTION
This is subjective, but 5% is not that rare, and my friend agrees it's annoying to constantly receive notifications for it.

For the record:
- Loch Emperor, the only other "rare" Galatea sea creature, which actually deserves the title, is 1%.
- Our top 2 most common "rare" marked sea creatures other than Ent are: Carrot King (5.76% - makes sense as it requires a special bait) and Abyssal Miner (1.8%).