### PR TITLE
No more Aura propaganda

### DIFF
--- a/constants/misc/EnforcedConfigValues.json
+++ b/constants/misc/EnforcedConfigValues.json
@@ -92,6 +92,21 @@
         "1.21.10"
       ],
       "extraMessage": "Will be re-enabled on version 5.2.0 and later"
+    },
+    {
+        "enforcedValues": [
+            {
+                "path": "dev.debug.auraPropaganda",
+                "value": false
+            }
+        ],
+        "affectedVersion": "6.0.0",
+        "affectedMinecraftVersions": [
+            "1.8.9",
+            "1.21.5",
+            "1.21.8",
+            "1.21.10"
+        ]
     }
   ]
 }


### PR DESCRIPTION
You can no longer vote for hannibal2, so there is no point in keeping this enabled.