### PR TITLE
Hide errors related to UserLuckBreakdown

### DIFF
--- a/constants/ChangedChatErrors.json
+++ b/constants/ChangedChatErrors.json
@@ -237,6 +237,12 @@
         "Unknown mayor found"
       ],
       "fixed_in": "5.3.0"
+    },
+    {
+      "message_starts_with": [
+        "Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.misc.UserLuckBreakdown"
+      ],
+      "fixed_in": "6.0.0"
     }
   ]
 }


### PR DESCRIPTION
This needs to be fixed at some point, but it is pretty inconsequential and is unnecessarily spamming people's chats in certain circumstances (I haven't managed to trigger it myself yet, maybe it requires high ping or a laggy server).