### PR TITLE
Fix Glacite Tunnels fairy soul names

### DIFF
--- a/constants/TunnelsGraph.json
+++ b/constants/TunnelsGraph.json
@@ -3116,14 +3116,14 @@
   },
   "331": {
     "Position": "20.0:121.0:240.0",
-    "Name": "§dFairy Soul Dr. Stone",
+    "Name": "§dFairy Soul Glacite Lake",
     "Neighbours": {
       "333": 2.45
     }
   },
   "332": {
     "Position": "111.0:160.0:412.0",
-    "Name": "§dFairy Soul Aquamarine",
+    "Name": "§dFairy Soul Citrine",
     "Neighbours": {
       "336": 11.05
     }

--- a/constants/TunnelsGraph.json
+++ b/constants/TunnelsGraph.json
@@ -1,6 +1,6 @@
 {
-  "//": "This file is no longer used by latest SkyHanni versions. Please edit constants/island_graphs/GLACITE_TUNNELS.json instead.",
   "0": {
+    "//": "This file is no longer used by latest SkyHanni versions. Please edit constants/island_graphs/GLACITE_TUNNELS.json instead.",
     "Position": "-68.0:132.0:407.0",
     "Name": "§8Onyx Gemstone",
     "Neighbours": {

--- a/constants/TunnelsGraph.json
+++ b/constants/TunnelsGraph.json
@@ -1,4 +1,5 @@
 {
+  "//": "This file is no longer used by latest SkyHanni versions. Please edit constants/island_graphs/GLACITE_TUNNELS.json instead.",
   "0": {
     "Position": "-68.0:132.0:407.0",
     "Name": "§8Onyx Gemstone",
@@ -3116,14 +3117,14 @@
   },
   "331": {
     "Position": "20.0:121.0:240.0",
-    "Name": "§dFairy Soul Glacite Lake",
+    "Name": "§dFairy Soul Dr. Stone",
     "Neighbours": {
       "333": 2.45
     }
   },
   "332": {
     "Position": "111.0:160.0:412.0",
-    "Name": "§dFairy Soul Citrine",
+    "Name": "§dFairy Soul Aquamarine",
     "Neighbours": {
       "336": 11.05
     }

--- a/constants/island_graphs/GLACITE_TUNNELS.json
+++ b/constants/island_graphs/GLACITE_TUNNELS.json
@@ -1436,7 +1436,7 @@
   },
   "146": {
     "Position": "-20.0:121.0:396.0",
-    "Name": "§dFairy Soul Glacite Lake",
+    "Name": "§dFairy Soul Lake",
     "Tags": [
       "fairy_soul"
     ],
@@ -3233,7 +3233,7 @@
   },
   "331": {
     "Position": "22.0:122.0:239.0",
-    "Name": "§dFairy Soul Glacite Lake",
+    "Name": "§dFairy Soul Dr. Stone",
     "Tags": [
       "fairy_soul"
     ],

--- a/constants/island_graphs/GLACITE_TUNNELS.json
+++ b/constants/island_graphs/GLACITE_TUNNELS.json
@@ -1436,7 +1436,7 @@
   },
   "146": {
     "Position": "-20.0:121.0:396.0",
-    "Name": "§dFairy Soul Dr. Stone",
+    "Name": "§dFairy Soul Glacite Lake",
     "Tags": [
       "fairy_soul"
     ],
@@ -3233,7 +3233,7 @@
   },
   "331": {
     "Position": "22.0:122.0:239.0",
-    "Name": "§dFairy Soul Dr. Stone",
+    "Name": "§dFairy Soul Glacite Lake",
     "Tags": [
       "fairy_soul"
     ],
@@ -3243,7 +3243,7 @@
   },
   "332": {
     "Position": "111.0:160.0:411.0",
-    "Name": "§dFairy Soul Aquamarine",
+    "Name": "§dFairy Soul Citrine",
     "Tags": [
       "fairy_soul"
     ],


### PR DESCRIPTION
- The Lake soul was incorrectly labeled as Dr. Stone (there is another one correctly labeled as Dr. Stone).
- The Aquamarine soul might have been an Aquamarine vein originally, but it is Citrine now.