### PR TITLE
Mage Shop -> Mage Emissary

### DIFF
--- a/constants/island_graphs/CRIMSON_ISLE.json
+++ b/constants/island_graphs/CRIMSON_ISLE.json
@@ -4697,9 +4697,9 @@
   },
   "540": {
     "Position": "-130.0:90.0:-725.0",
-    "Name": "Mage Shop",
+    "Name": "Mage Emissary",
     "Tags": [
-      "poi"
+      "npc"
     ],
     "Neighbours": {
       "542": 4.0,


### PR DESCRIPTION
For consistency with Barbarian Emissary and discoverability. It doesn't say "Mage Shop" in game.