### PR TITLE
Add remaining Aura perks to forced mayor perks

### DIFF
--- a/constants/misc/ForcedRepoPerks.json
+++ b/constants/misc/ForcedRepoPerks.json
@@ -1,6 +1,10 @@
 {
   "perks": [
+    "FUNDRAISING",
+    "UNIVERSAL_INCOME",
+    "WORK_BETTER",
     "WORK_HARDER",
+    "WORK_SMARTER",
     "DOUBLE_MOBS_HP",
     "STATSPOCALYPSE",
     "MYTHOLOGICAL_RITUAL",


### PR DESCRIPTION
I didn't realize adding Work Harder would make it show on the scoreboard, might as well add the rest that are active then.