### PR TITLE
Disable Reverse Party Transfer Clickable Message

### DIFF
--- a/constants/misc/EnforcedConfigValues.json
+++ b/constants/misc/EnforcedConfigValues.json
@@ -138,6 +138,21 @@
         "1.21.10"
       ],
       "extraMessage": "Fungi Cutters no longer have a mode"
+    },
+    {
+      "enforcedValues": [
+        {
+          "path": "misc.commands.reversePT.command",
+          "value": false
+        }
+      ],
+      "affectedVersion": "6.9.0",
+      "affectedMinecraftVersions": [
+        "1.21.5",
+        "1.21.8",
+        "1.21.10"
+      ],
+      "extraMessage": "Will be re-enabled next beta"
     }
   ]
 }

--- a/constants/misc/EnforcedConfigValues.json
+++ b/constants/misc/EnforcedConfigValues.json
@@ -142,7 +142,7 @@
     {
       "enforcedValues": [
         {
-          "path": "misc.commands.reversePT.command",
+          "path": "misc.commands.reversePT.clickable",
           "value": false
         }
       ],


### PR DESCRIPTION
Will be fixed by hannibal002/SkyHanni#5103. This feature can currently cause infinite recursion which can lead to freezes, log spam, an error in chat, and for example if Sound Responses is enabled, it can also spam a lot of animal sounds all at once in unlucky cases.