### PR TITLE
Remove Mushroom Armor suggestion from Bingo guide

### DIFF
--- a/constants/Bingo.json
+++ b/constants/Bingo.json
@@ -301,8 +301,7 @@
       "guide": [
         "Wear armor enchanted with Growth 5 ",
         "(Enchanting Level 5), preferably Ender Armor",
-        "while you're in The End or Mushroom Armor",
-        "during the night.",
+        "while you're in The End.",
         "Applying Growth 5 costs 50 Levels each.",
         "If you still struggle, reforge your",
         "armor to Titanic."


### PR DESCRIPTION
> - Removed Mushroom Armor's 3x stats ability

– https://hypixel.net/threads/february-2-skyblock-patch-notes.6056168/#post-41522530