### PR TITLE
Silence CustomScoreboard unknown line errors

### DIFF
--- a/constants/ChangedChatErrors.json
+++ b/constants/ChangedChatErrors.json
@@ -261,6 +261,12 @@
         "VertexFormatElement ID 6 was already taken, using 7 instead"
       ],
       "fixed_in": "7.6.0"
+    },
+    {
+      "message_starts_with": [
+        "CustomScoreboard detected an unknown line"
+      ],
+      "fixed_in": "7.8.0"
     }
   ]
 }


### PR DESCRIPTION
IslandChangeEvent being bugged causes a lot of these, particularly Flight Duration and Time Elapsed can spam every second.