### PR TITLE
Nutcracker LEGENDARY -> EPIC, remove rare flag

### DIFF
--- a/constants/SeaCreatures.json
+++ b/constants/SeaCreatures.json
@@ -115,8 +115,7 @@
       "Nutcracker": {
         "chat_message": "§aYou found a forgotten Nutcracker laying beneath the ice.",
         "fishing_experience": 950,
-        "rarity": "LEGENDARY",
-        "rare": true
+        "rarity": "EPIC"
       },
       "Yeti": {
         "chat_message": "§aWhat is this creature!?",


### PR DESCRIPTION
It's much more common now (~2% -> ~15%), less desirable because no more Lily Pad drops, and we have `/shseacreatures` for anyone who opts in to receiving notifications for them.