### PR TITLE
Fix JSON syntax error in Contributors.json

### DIFF
--- a/constants/Contributors.json
+++ b/constants/Contributors.json
@@ -99,7 +99,7 @@
       "suffix": "§z(:"
     },
     "owoLuna": {
-      "suffix": "§5:3"
+      "suffix": "§5:3",
       "alt from": "qtLuna"
     },
     "oxsss": {},


### PR DESCRIPTION
I messed up my last PR. This should only affect old versions, but technically they are still able to join SkyBlock, so worth fixing.