### PR TITLE
Add list of items with legacy gemstone slots

### DIFF
--- a/constants/Items.json
+++ b/constants/Items.json
@@ -246,5 +246,8 @@
     "CURSUS_FERAE",
     "APEX_PRAEDATOR",
     "NEX_TITANUM"
+  ],
+  "has_legacy_gemstone_slots": [
+    "GIANT_FISHING_ROD"
   ]
 }


### PR DESCRIPTION
This will be used for https://github.com/hannibal002/SkyHanni/pull/5591 to silence errors when people interact with outdated copies of certain items that used to have gemstone slots.