### PR TITLE
Add malware warning

### DIFF
--- a/constants/misc/EnforcedConfigValues.json
+++ b/constants/misc/EnforcedConfigValues.json
@@ -1,6 +1,21 @@
 {
   "enforced_config_values": [
     {
+      "enforcedValues": [],
+      "minimumAffectedVersion": "8.0.0",
+      "affectedVersion": "8.0.2",
+      "notificationPSA": [
+        "§c§lThe version of SkyHanni you have installed contains malware.",
+        "§c§lYou should IMMEDIATELY remove it and change any important passwords.",
+        "§c§lYou can download a safe version of the mod from Modrinth."
+      ],
+      "chatPSA": [
+        "§c§lThe version of SkyHanni you have installed contains malware.",
+        "§c§lYou should IMMEDIATELY remove it and change any important passwords.",
+        "§c§lYou can download a safe version of the mod from Modrinth."
+      ]
+    },
+    {
       "enforcedValues": [
         {
           "path": "misc.fixDoubleClicks",

--- a/constants/misc/EnforcedConfigValues.json
+++ b/constants/misc/EnforcedConfigValues.json
@@ -1,6 +1,15 @@
 {
   "enforced_config_values": [
     {
+      "enforcedValues": [
+        {
+          "path": "about.fullAutoUpdates",
+          "value": false
+        }
+      ],
+      "affectedVersion": "99.99.99"
+    },
+    {
       "enforcedValues": [],
       "minimumAffectedVersion": "8.0.0",
       "affectedVersion": "8.0.2",


### PR DESCRIPTION
Adds a warning for the ratted versions of SkyHanni (8.0.0–8.0.2) and disables fullAutoUpdates on all versions as a safeguard.