### PR TITLE
Slightly tighten malware warning

### DIFF
--- a/constants/misc/EnforcedConfigValues.json
+++ b/constants/misc/EnforcedConfigValues.json
@@ -13,6 +13,10 @@
       "enforcedValues": [],
       "minimumAffectedVersion": "8.0.0",
       "affectedVersion": "8.0.2",
+      "affectedMinecraftVersions": [
+        "1.21.10",
+        "1.21.11"
+      ],
       "notificationPSA": [
         "§c§lThe version of SkyHanni you have installed contains malware.",
         "§c§lYou should IMMEDIATELY remove it and change any important passwords.",


### PR DESCRIPTION
Just in case – `minimumAffectedVersion` is supported in 4.25.0 and above (first version to support 1.21.10), while `affectedMinecraftVersions` is supported in 3.7.0 and above (which did not even support 1.21.5 yet).