### PR TITLE
Update suppressed error messages

### DIFF
--- a/constants/ChangedChatErrors.json
+++ b/constants/ChangedChatErrors.json
@@ -70,9 +70,9 @@
     },
     {
       "message_starts_with": [
-        "Caught a IllegalStateException in at.hannibal2.skyhanni.features.bingo.BingoApi.onSecondPassed"
+        "Caught a IllegalStateException in at.hannibal2.skyhanni.features.bingo.BingoApi"
       ],
-      "fixed_in": "7.14.0"
+      "fixed_in": "7.19.0"
     },
     {
       "message_starts_with": [
@@ -97,6 +97,11 @@
         "Could not find gemstone slot price for"
       ],
       "fixed_in": "7.12.0"
-    }
+    },
+    {
+      "message_starts_with": [
+        "Asynchronous exception caught in election api fetch"
+      ],
+      "fixed_in": "7.19.0"
   ]
 }

--- a/constants/ChangedChatErrors.json
+++ b/constants/ChangedChatErrors.json
@@ -103,5 +103,6 @@
         "Asynchronous exception caught in election api fetch"
       ],
       "fixed_in": "7.19.0"
+    }
   ]
 }


### PR DESCRIPTION
- Bump BingoApi error to 7.19.0 and widen the suppression a bit. [hannibal002/SkyHanni#5636]
- Suppress ElectionApi error that is a Hypixel moment (zero perk minister). [hannibal002/SkyHanni#5641]