### PR TITLE
Add fullSearchPrefix to wikis

### DIFF
--- a/constants/misc/Wiki.json
+++ b/constants/misc/Wiki.json
@@ -2,11 +2,13 @@
   "official": {
     "name": "Official SkyBlock Wiki",
     "urlPrefix": "https://wiki.hypixel.net/",
-    "searchPrefix": "index.php?search="
+    "searchPrefix": "index.php?search=",
+    "fullSearchPrefix": "https://wiki.hypixel.net/index.php?search="
   },
   "unofficial": {
     "name": "Independent SkyBlock Wiki",
     "urlPrefix": "https://hypixelskyblock.minecraft.wiki/w/",
-    "searchPrefix": "?title=Special:Search&search="
+    "searchPrefix": "?title=Special:Search&search=",
+    "fullSearchPrefix": "https://hypixelskyblock.minecraft.wiki/?title=Special:Search&search="
   }
 }


### PR DESCRIPTION
Preparation for a SkyHanni PR. Not urgent, but it should be safe to merge without breaking any existing functionality. The old deprecated `searchPrefix` field will stay for backwards compatibility for the time being.