### PR TITLE
Force Pelt-pocalypse

### DIFF
--- a/constants/misc/ForcedRepoPerks.json
+++ b/constants/misc/ForcedRepoPerks.json
@@ -1,4 +1,5 @@
 {
   "perks": [
+    "PELT_POCALYPSE"
   ]
 }


### PR DESCRIPTION
It's essentially permanent with the new update, this lets older versions use the proper trapper cooldown.