### PR TITLE
Disable Custom Keybinds for 7.18.0/7.19.0

### DIFF
--- a/constants/misc/EnforcedConfigValues.json
+++ b/constants/misc/EnforcedConfigValues.json
@@ -133,7 +133,7 @@
       ],
       "minimumAffectedVersion": "7.18.0",
       "affectedVersion": "7.19.0",
-      "extraMessage": "Will be re-enabled next beta"
+      "extraMessage": "Will be re-enabled in 7.20.0 and above"
     }
   ]
 }

--- a/constants/misc/EnforcedConfigValues.json
+++ b/constants/misc/EnforcedConfigValues.json
@@ -123,6 +123,17 @@
         "1.21.11"
       ],
       "extraMessage": "Will be re-enabled next beta"
+    },
+    {
+      "enforcedValues": [
+        {
+          "path": "garden.keyBind.enabled",
+          "value": false
+        }
+      ],
+      "minimumAffectedVersion": "7.18.0",
+      "affectedVersion": "7.19.0",
+      "extraMessage": "Will be re-enabled next beta"
     }
   ]
 }


### PR DESCRIPTION
I messed up and my toggle support resulted in inputs getting stuck sometimes. I don't want this to cause anyone to inadvertently fail a macro check and get banned.