### PR TITLE
Fix: Remove Wrong Fairy soul tag

### DIFF
--- a/constants/island_graphs/THE_PARK.json
+++ b/constants/island_graphs/THE_PARK.json
@@ -184,8 +184,7 @@
     "Name": "Spruce Woods",
     "Tags": [
       "area",
-      "teleport_pad",
-      "fairy_soul"
+      "teleport_pad"
     ],
     "Neighbours": {
       "325": 27.59


### PR DESCRIPTION
## What
Removes incorrect Fairy Soul tag that was placed in the Park where no Fairy Soul exists.
In park only 12 Fairy souls.

## Changelog Technical Details
+ Removed invalid Fairy Soul tag in park. - legentpc