### PR TITLE
disable Starred Mob Highlight it ESPs mobs.

### DIFF
--- a/constants/misc/EnforcedConfigValues.json
+++ b/constants/misc/EnforcedConfigValues.json
@@ -142,7 +142,9 @@
           "value": false
         }
       ],
-      "affectedVersion": "7.19.0"
+      "affectedVersion": "7.19.0",
+      "minimumAffectedVersion": "1.0.0",
+      "extraMessage": "Will be re-enabled in 7.20.0 and above"
     }
   ]
 }

--- a/constants/misc/EnforcedConfigValues.json
+++ b/constants/misc/EnforcedConfigValues.json
@@ -142,7 +142,7 @@
           "value": false
         }
       ],
-      "affectedVersion": "99.99.99"
+      "affectedVersion": "7.19.0"
     }
   ]
 }

--- a/constants/misc/EnforcedConfigValues.json
+++ b/constants/misc/EnforcedConfigValues.json
@@ -134,6 +134,15 @@
       "minimumAffectedVersion": "7.18.0",
       "affectedVersion": "7.19.0",
       "extraMessage": "Will be re-enabled in 7.20.0 and above"
+    },
+    {
+      "enforcedValues": [
+        {
+          "path": "dungeon.objectHighlighter.starred.highlight",
+          "value": false
+        }
+      ],
+      "affectedVersion": "99.99.99"
     }
   ]
 }

--- a/constants/misc/EnforcedConfigValues.json
+++ b/constants/misc/EnforcedConfigValues.json
@@ -143,7 +143,6 @@
         }
       ],
       "affectedVersion": "7.19.0",
-      "minimumAffectedVersion": "1.0.0",
       "extraMessage": "Will be re-enabled in 7.20.0 and above"
     }
   ]


### PR DESCRIPTION
ever since 1.21.10 we have had an issue where non Xray Glow would work through walls on Skull based helmets worn by entities.

 this was finally fixed under https://github.com/hannibal002/SkyHanni/pull/5700