### PR TITLE
Add chatPSA for 1.21.10

### DIFF
--- a/constants/misc/EnforcedConfigValues.json
+++ b/constants/misc/EnforcedConfigValues.json
@@ -36,7 +36,7 @@
       ],
       "chatPSA": [
         "§cSkyHanni is no longer receiving updates for Minecraft 1.21.10.",
-        "§cThere are known issues with NEU repo, please do not report them.",
+        "§cThere are known issues with NEU repo in this version, please do not report them.",
         "§cUpdate to 1.21.11 to continue receiving bugfixes and new features."
       ]
     },

--- a/constants/misc/EnforcedConfigValues.json
+++ b/constants/misc/EnforcedConfigValues.json
@@ -29,6 +29,18 @@
       ]
     },
     {
+      "enforcedValues": [],
+      "affectedVersion": "7.11.0",
+      "affectedMinecraftVersions": [
+        "1.21.10"
+      ],
+      "chatPSA": [
+        "§cSkyHanni is no longer receiving updates for Minecraft 1.21.10.",
+        "§cThere are known issues with NEU repo, please do not report them.",
+        "§cUpdate to 1.21.11 to continue receiving bugfixes and new features."
+      ]
+    },
+    {
       "enforcedValues": [
         {
           "path": "misc.fixDoubleClicks",


### PR DESCRIPTION
The DiscontinuedMinecraftVersions notice isn't exactly visible unless they try to open the update section in the config. Way too many people still reporting issues with 1.21.10 on Discord.