### PR TITLE
feat: add burningsoul shard name override

### DIFF
--- a/constants/Items.json
+++ b/constants/Items.json
@@ -423,7 +423,8 @@
     "CINDERBAT": "CINDER_BAT",
     "END_STONE_PROTECTOR": "ENDSTONE_PROTECTOR",
     "LOCH_EMPEROR": "SEA_EMPEROR",
-    "BOGGED": "SEA_ARCHER"
+    "BOGGED": "SEA_ARCHER",
+    "INFERNO_DEMONLORD": "BURNINGSOUL"
   },
   "distance_enchant_data": {
     "LEGION": {


### PR DESCRIPTION
Fixes Missing Shard Data warning