### PR TITLE
Fix: Woodsplitter isn't a Stacking Enchant

### DIFF
--- a/constants/Enchants.json
+++ b/constants/Enchants.json
@@ -707,6 +707,12 @@
       "nbtName": "vicious",
       "goodLevel": 0,
       "maxLevel": 5
+    },
+    "woodsplitter": {
+      "loreName": "Woodsplitter",
+      "nbtName": "arcane",
+      "goodLevel": 5,
+      "maxLevel": 6
     }
   },
   "ULTIMATE": {
@@ -930,12 +936,6 @@
       "maxLevel": 10,
       "statLabel": "toxophileCombatXp",
       "stackLevel": [0, 50000, 100000, 250000, 500000, 1000000, 1500000, 2000000, 2500000, 3000000]
-    },
-    "woodsplitter": {
-      "loreName": "Woodsplitter",
-      "nbtName": "arcane",
-      "goodLevel": 5,
-      "maxLevel": 6
     }
   }
 }


### PR DESCRIPTION
idk why it was in the stacking category but it's not a stacking enchant