### PR TITLE
Silence message edit/delete errors

### DIFF
--- a/constants/ChangedChatErrors.json
+++ b/constants/ChangedChatErrors.json
@@ -189,7 +189,7 @@
         "Error while editing message",
         "Error while deleting message"
       ],
-      "fixed_in": "7.25.0",
+      "fixed_in": "7.25.0"
     }
   ]
 }

--- a/constants/ChangedChatErrors.json
+++ b/constants/ChangedChatErrors.json
@@ -183,6 +183,13 @@
       ],
       "fixed_in": "7.24.0",
       "custom_message": "SkyHanni ran into an error with island detection. Please update to 7.24.0 or newer to fix the issue."
+    },
+    {
+      "message_starts_with": [
+        "Error while editing message",
+        "Error while deleting message"
+      ],
+      "fixed_in": "7.25.0",
     }
   ]
 }


### PR DESCRIPTION
These are basically harmless, we don't need more people reporting them. Will be fixed with hannibal002/SkyHanni#5843 (only affects 1.21.11).