### PR TITLE
Fix 2 Hoppity API names for Lotus Atoll

### DIFF
--- a/constants/HoppityEggLocations.json
+++ b/constants/HoppityEggLocations.json
@@ -660,9 +660,9 @@
       "lotus_entrance": "-7:71:-4",
       "lotus_kay": "21:83:-45",
       "lotus_flower": "32:67:1",
-      "lotus_lovely_path": "8:71:-11",
+      "lotus_path": "8:71:-11",
       "lotus_beach": "58:67:-40",
-      "lotus_treasure_cave": "77:72:-6"
+      "lotus_treasure": "77:72:-6"
     }
   },
   "chocolateFactoryMilestones": [


### PR DESCRIPTION
I trusted what I was given by someone else for the last batch of 3 and apparently 2 out of 3 were just flat out wrong, again.