### PR TITLE
Force beta channel on 7.17.0–7.25.0

### DIFF
--- a/constants/misc/EnforcedConfigValues.json
+++ b/constants/misc/EnforcedConfigValues.json
@@ -155,6 +155,17 @@
       "minimumAffectedVersion": "7.21.0",
       "affectedVersion": "7.21.0",
       "extraMessage": "Update to 7.22.0 to re-enable this feature"
+    },
+    {
+      "enforcedValues": [
+        {
+          "path": "about.updateStream",
+          "value": "BETA"
+        }
+      ],
+      "minimumAffectedVersion": "7.17.0",
+      "affectedVersion": "7.25.0",
+      "extraMessage": "Ensuring you get notified of important updates (this is not auto update)"
     }
   ]
 }


### PR DESCRIPTION
The reworked updater is incorrectly defaulting to the full release stream for fresh installs of SkyHanni even if the user installs a beta version, so I'm forcing the update stream to beta for 7.17.0–7.25.0 (none of which have auto-update) to make sure users get don't miss important updates. The notification is not intrusive anyway, it's only once per game start, so even if someone intentionally set it to full I'm sure they'll be fine.