### PR TITLE
Fix invalid enforced config path

### DIFF
--- a/constants/misc/EnforcedConfigValues.json
+++ b/constants/misc/EnforcedConfigValues.json
@@ -146,7 +146,7 @@
           "value": false
         },
         {
-          "path": "event.gifting.giftingOpportunities",
+          "path": "event.gifting.giftingOpportunities.enabled",
           "value": false
         },
         {


### PR DESCRIPTION
This is an old version, but still relevant to new versions:
```
SkyHanni 7.11.0 1.21.10: Caught a JsonSyntaxException in at.hannibal2.skyhanni.config.EnforcedConfigValues.onGuiOpen(at.hannibal2.skyhanni.events.render.gui.GuiScreenOpenEvent) at GuiScreenOpenEvent: java.lang.IllegalStateException: Expected BEGIN_OBJECT but was BOOLEAN at path $
 
Caused by com.google.gson.JsonSyntaxException: java.lang.IllegalStateException: Expected BEGIN_OBJECT but was BOOLEAN at path $
    at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:520)
    at com.google.gson.Gson.fromJson(Gson.java:1361)
    at com.google.gson.Gson.fromJson(Gson.java:1463)
    at com.google.gson.Gson.fromJson(Gson.java:1406)
    at SH.utils.json.Shimmy.setJson(Shimmy.kt:64)
    at SH.config.EnforcedConfigValues.enforceOntoConfig(EnforcedConfigValues.kt:83)
    at SH.config.EnforcedConfigValues.onGuiOpen(EnforcedConfigValues.kt:43)
<Skyhanni event post>
Caused by java.lang.IllegalStateException: Expected BEGIN_OBJECT but was BOOLEAN at path $
    at com.google.gson.internal.bind.JsonTreeReader.expect(JsonTreeReader.java:179)
    at com.google.gson.internal.bind.JsonTreeReader.beginObject(JsonTreeReader.java:96)
    at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:509)
    at com.google.gson.Gson.fromJson(Gson.java:1361)
    at com.google.gson.Gson.fromJson(Gson.java:1463)
    at com.google.gson.Gson.fromJson(Gson.java:1406)
    at SH.utils.json.Shimmy.setJson(Shimmy.kt:64)
    at SH.config.EnforcedConfigValues.enforceOntoConfig(EnforcedConfigValues.kt:83)
    at SH.config.EnforcedConfigValues.onGuiOpen(EnforcedConfigValues.kt:43)
<Skyhanni event post>
```