### PR TITLE
Disable Fix Transfer Cooldown

### DIFF
--- a/constants/misc/EnforcedConfigValues.json
+++ b/constants/misc/EnforcedConfigValues.json
@@ -179,6 +179,15 @@
       "minimumAffectedVersion": "7.21.0",
       "affectedVersion": "7.21.0",
       "extraMessage": "Update the mod to re-enable this feature"
+    },
+    {
+      "enforcedValues": [
+        {
+          "path": "commands.transferCooldown",
+          "value": false
+        },
+        "affectedVersion": "9.9.9"
+      ]
     }
   ]
 }

--- a/constants/misc/EnforcedConfigValues.json
+++ b/constants/misc/EnforcedConfigValues.json
@@ -186,8 +186,8 @@
           "path": "commands.transferCooldown",
           "value": false
         },
-        "affectedVersion": "9.9.9"
-      ]
+      ],
+      "affectedVersion": "9.9.9"
     }
   ]
 }

--- a/constants/misc/EnforcedConfigValues.json
+++ b/constants/misc/EnforcedConfigValues.json
@@ -185,7 +185,7 @@
         {
           "path": "commands.transferCooldown",
           "value": false
-        },
+        }
       ],
       "affectedVersion": "9.9.9"
     }


### PR DESCRIPTION
It probably doesn't work most of the time anyway due to Hypixel increasing the cooldown for Year 500, but also there's a wardrobe wipe going on that happens if you quickly switch lobbies after switching your active wardrobe slot so like, might as well not inadvertently assist in people getting their items wiped? Will re-enable once it seems all clear.