### PR TITLE
Add ultra_rare_rewards list for non-book ultra rare experimentation table drops

### DIFF
--- a/constants/ExperimentationTable.json
+++ b/constants/ExperimentationTable.json
@@ -23,5 +23,19 @@
     "FATEFUL_STINGER",
     "VIBRANT_CORAL",
     "DYE_NADESHIKO"
+  ],
+  "ultra_rare_rewards": [
+    "SEVERED_PINCER",
+    "ENDSTONE_IDOL",
+    "ENSNARED_SNAIL",
+    "GOLDEN_BOUNTY",
+    "SEVERED_HAND",
+    "GOLD_BOTTLE_CAP",
+    "CHAIN_END_TIMES",
+    "OCTOPUS_TENDRIL",
+    "TROUBLED_BUBBLE",
+    "PESTHUNTING_GUIDE",
+    "FATEFUL_STINGER",
+    "VIBRANT_CORAL"
   ]
 }


### PR DESCRIPTION
### What
- Adds an `ultra_rare_rewards` list to `ExperimentationTable.json`, containing non-book items that share the same Ultra Rare rarity tier as max-tier enchant books.

### Needed for:
- https://github.com/hannibal002/SkyHanni/pull/5981