### PR TITLE
Silence Harvest Feast failed to fetch error

### DIFF
--- a/constants/misc/EnforcedConfigValues.json
+++ b/constants/misc/EnforcedConfigValues.json
@@ -188,6 +188,16 @@
         }
       ],
       "affectedVersion": "9.9.9"
+    },
+    {
+      "enforcedValues": [
+        {
+          "path": "event.feast.fetchAutomatically",
+          "value": false
+        }
+      ],
+      "affectedVersion": "7.32.0",
+      "extraMessage": "Will be re-enabled in 7.33.0"
     }
   ]
 }

--- a/constants/misc/EnforcedConfigValues.json
+++ b/constants/misc/EnforcedConfigValues.json
@@ -197,7 +197,7 @@
         }
       ],
       "affectedVersion": "7.32.0",
-      "extraMessage": "Will be re-enabled in 7.33.0"
+      "extraMessage": "Will be re-enabled in 7.33.0. For now, talk to Ted to refresh."
     }
   ]
 }


### PR DESCRIPTION
This does also break manual `/shresetfeastdata` but talking to Ted should still work & new beta soon plus https://github.com/hannibal002/SkyHanni/pull/6043 will fix that for the future in case we need to disable it again.