### PR TITLE
Add the alpha new island types to REPO

### DIFF
--- a/constants/misc/IslandType.json
+++ b/constants/misc/IslandType.json
@@ -183,6 +183,16 @@
         "min_z": -78
       }
     },
+    "TORRHUS_CANYON": {
+      "name": "Torrhus Canyon",
+      "api_name": "foraging_3",
+      "max_players": 12
+    },
+    "SAFARI": {
+      "name": "Safari",
+      "api_name": "safari",
+      "max_players": 4
+    },
     "NONE": {
       "name": ""
     },


### PR DESCRIPTION
I hope this fixes it, since it used api_name to detect using HypixelLocationApi, so probably works.
This api_name have been verified.
The max_players are just guesses but are probably right.