### PR TITLE
Remove Raffle multiplier from arbitrary multiplier.

### DIFF
--- a/constants/Slayer.json
+++ b/constants/Slayer.json
@@ -496,7 +496,6 @@
     "MOAR_SKILLZ": 1.5,
     "WORK_SMARTER": 1.5
   },
-  "arbitrary_multiplier": 1.5,
-  "__WhyCurrently": "This Is currently here for the Year 500 celebrations which start(ed) at 1782921600 and should end at 1783526400.",
+  "arbitrary_multiplier": 1.0,
   "__info__": "This Arbitrary Multiplier is in case seasonal multipliers gets fixed as they currently don't work on Slayers (except for Raffle's 50% that started existing as of Year 500."
 }


### PR DESCRIPTION
Raffle is over and as far as I know the 50% is as well but I did just ask Luna to check because I might be wrong