### PR TITLE
Fix Wither Spectre Shard name

### DIFF
--- a/constants/Items.json
+++ b/constants/Items.json
@@ -437,7 +437,7 @@
     "INKLING": "NIGHT_SQUID",
     "LOTUSFISH": "LOTUS_FISH",
     "SEASHINE": "SEA_SHINE",
-    "WITHER_SPECTER": "WITHER_SPECTRE"
+    "WITHER_SPECTRE": "WITHER_SPECTER"
   },
   "distance_enchant_data": {
     "LEGION": {

--- a/constants/Items.json
+++ b/constants/Items.json
@@ -436,7 +436,8 @@
     "FLIPFLOPPER": "FLIP_FLOPPER",
     "INKLING": "NIGHT_SQUID",
     "LOTUSFISH": "LOTUS_FISH",
-    "SEASHINE": "SEA_SHINE"
+    "SEASHINE": "SEA_SHINE",
+    "WITHER_SPECTER": "WITHER_SPECTRE"
   },
   "distance_enchant_data": {
     "LEGION": {


### PR DESCRIPTION
Hypixel finally fixed it, but SkyHanni is too dumb to pick it up from the NEU repo.