### PR TITLE
Remove Fix Transfer Cooldown override

### DIFF
--- a/constants/misc/EnforcedConfigValues.json
+++ b/constants/misc/EnforcedConfigValues.json
@@ -179,15 +179,6 @@
       "minimumAffectedVersion": "7.21.0",
       "affectedVersion": "7.21.0",
       "extraMessage": "Update the mod to re-enable this feature"
-    },
-    {
-      "enforcedValues": [
-        {
-          "path": "commands.transferCooldown",
-          "value": false
-        }
-      ],
-      "affectedVersion": "9.9.9"
     }
   ]
 }


### PR DESCRIPTION
I don't know if this even worked in the first place since I saw people with an up-to-date mod still having it enabled, but the wipes should be fixed and the raffle is over now, so it should be fine to re-enable regardless.