### PR TITLE
Add enchanted ink sack to fishing profit tracker

### DIFF
--- a/constants/FishingProfitItems.json
+++ b/constants/FishingProfitItems.json
@@ -57,6 +57,7 @@
       "GUARDIAN;0",
       "MUSIC_RUNE;1",
       "INK_SACK",
+      "ENCHANTED_INK_SACK",
       "WATER_LILY",
       "RED_MUSHROOM",
       "AGARIMOO_TONGUE",


### PR DESCRIPTION
Adds `ENCHANTED_INK_SACK` to `FishingProfitItems.json` so enchanted ink sacks obtained while fishing are accepted by the fishing profit tracker. (drops from squid and inkling)