### PR TITLE
Force Better Wiki

### DIFF
--- a/constants/misc/EnforcedConfigValues.json
+++ b/constants/misc/EnforcedConfigValues.json
@@ -189,7 +189,7 @@
         {
           "path": "misc.commands.betterWiki.useIndependent",
           "value": true
-        },
+        }
       ],
       "affectedVersion": "7.99.0",
       "extraMessage": "Official wiki is dead"

--- a/constants/misc/EnforcedConfigValues.json
+++ b/constants/misc/EnforcedConfigValues.json
@@ -179,6 +179,20 @@
       "minimumAffectedVersion": "7.21.0",
       "affectedVersion": "7.21.0",
       "extraMessage": "Update the mod to re-enable this feature"
+    },
+    {
+      "enforcedValues": [
+        {
+          "path": "misc.commands.betterWiki.enabled",
+          "value": true
+        },
+        {
+          "path": "misc.commands.betterWiki.useIndependent",
+          "value": true
+        },
+      ],
+      "affectedVersion": "7.99.0",
+      "extraMessage": "Official wiki is dead"
     }
   ]
 }


### PR DESCRIPTION
Hypixel has removed the `/wiki` and `/wikithis` commands, and the official wiki ~~is going to be~~ has been completely shut down ~~soon~~.

There's basically no other mods registering these commands right now that I know of, but this enforcement will not be permanent, so that players can use other mods in the future.

I set the target to 7.99.0 for now since I don't know when my PR that makes the enforcement no longer necessary will be done and merged, but probably before 9.0.0.