### PR TITLE
Improve Better Wiki enforcement

### DIFF
--- a/constants/misc/EnforcedConfigValues.json
+++ b/constants/misc/EnforcedConfigValues.json
@@ -183,7 +183,7 @@
     {
       "enforcedValues": [
         {
-          "path": "misc.commands.betterWiki.useUnofficial",
+          "path": "misc.commands.betterWiki.useFandom",
           "value": false
         }
       ],

--- a/constants/misc/EnforcedConfigValues.json
+++ b/constants/misc/EnforcedConfigValues.json
@@ -183,7 +183,21 @@
     {
       "enforcedValues": [
         {
+          "path": "misc.commands.betterWiki.useUnofficial",
+          "value": false
+        }
+      ],
+      "affectedVersion": "6.16.0",
+      "extraMessage": "No free traffic for Fandom, update your mod"
+    },
+    {
+      "enforcedValues": [
+        {
           "path": "misc.commands.betterWiki.enabled",
+          "value": true
+        },
+        {
+          "path": "misc.commands.betterWiki.useUnofficial",
           "value": true
         },
         {
@@ -191,6 +205,7 @@
           "value": true
         }
       ],
+      "minimumAffectedVersion": "6.17.0",
       "affectedVersion": "7.99.0",
       "extraMessage": "Official wiki is dead"
     }


### PR DESCRIPTION
- Added a minimum version of 6.17.0, just in case, to avoid the tiny chance of anyone still being on such an old version getting directed to Fandom
- Also enforced the pre-7.21.0 config option name to direct more users to the independent wiki