### PR TITLE
Fix: Torrhus max player count

### DIFF
--- a/constants/misc/IslandType.json
+++ b/constants/misc/IslandType.json
@@ -186,7 +186,7 @@
     "TORRHUS_CANYON": {
       "name": "Torrhus Canyon",
       "api_name": "foraging_3",
-      "max_players": 12,
+      "max_players": 24,
       "bounds": {
         "max_x": -499,
         "min_x": -770,


### PR DESCRIPTION
I think its 24. 
Max i saw was 23 but 23 is such an odd number for players