### PR TITLE
Silence CME from ParticleEvent accessing entities

### DIFF
--- a/constants/ChangedChatErrors.json
+++ b/constants/ChangedChatErrors.json
@@ -190,6 +190,21 @@
         "Caught a NullPointerException in at.hannibal2.skyhanni.data.MiningApi"
       ],
       "fixed_in": "7.43.0"
+    },
+    {
+      "message_starts_with": [
+        "Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.combat.FlareDisplay",
+        "Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.event.diana.GriffinBurrowParticleFinder",
+        "Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.event.hoppity.HoppityEggLocator",
+        "Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.hunting.InvisibugHighlighter",
+        "Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.misc.LesserOrbHider",
+        "Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.misc.ParticleHider.onParticle",
+        "Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.rift.area.livingcave.LivingCaveDefenseBlocks",
+        "Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.slayer.HideSlayerSpawnParticles",
+        "Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.slayer.VampireSlayerFeatures",
+        "Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.slayer.enderman.EndermanSlayerHideParticles"
+      ],
+      "fixed_in": "7.99.0"
     }
   ]
 }

--- a/constants/ChangedChatErrors.json
+++ b/constants/ChangedChatErrors.json
@@ -193,15 +193,15 @@
     },
     {
       "message_starts_with": [
-        "Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.combat.FlareDisplay",
-        "Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.event.diana.GriffinBurrowParticleFinder",
-        "Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.event.hoppity.HoppityEggLocator",
-        "Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.hunting.InvisibugHighlighter",
-        "Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.misc.LesserOrbHider",
+        "Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.combat.FlareDisplay.onParticle",
+        "Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.event.diana.GriffinBurrowParticleFinder.onParticle",
+        "Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.event.hoppity.HoppityEggLocator.onParticle",
+        "Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.hunting.InvisibugHighlighter.onParticle",
+        "Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.misc.LesserOrbHider.onParticle",
         "Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.misc.ParticleHider.onParticle",
-        "Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.rift.area.livingcave.LivingCaveDefenseBlocks",
-        "Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.slayer.HideSlayerSpawnParticles",
-        "Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.slayer.VampireSlayerFeatures",
+        "Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.rift.area.livingcave.LivingCaveDefenseBlocks.onParticle",
+        "Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.slayer.HideSlayerSpawnParticles.onParticle",
+        "Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.slayer.VampireSlayerFeatures.onParticle",
         "Caught a ConcurrentModificationException in at.hannibal2.skyhanni.features.slayer.enderman.EndermanSlayerHideParticles"
       ],
       "fixed_in": "7.99.0"


### PR DESCRIPTION
It kept happening to players, and since no fix has come up.
It will just be silenced from now.

(Fixing the network thread accessing the entities is a bit problematic)
A proper fix would maybe be to seperate ParticleRenderEvent and ParticleSpawnEvent. But for now just silence it.