### PR TITLE
Fix: Megatree -> Mega Tree

### DIFF
--- a/constants/island_graphs/TORRHUS_CANYON.json
+++ b/constants/island_graphs/TORRHUS_CANYON.json
@@ -10423,7 +10423,7 @@
   },
   "1237": {
     "Position": "-540.0:111.0:278.0",
-    "Name": "Megatree",
+    "Name": "Mega Tree",
     "Tags": [
       "poi"
     ],


### PR DESCRIPTION
BEEHEEMOTH! A Beeheemoth has spawned at Mega Tree!

You tried to cut the Mega Tree and were fined 1,000 Coins by the Tree Protection Agency!