### PR TITLE
Silence Bingo Api background fetch api

### DIFF
--- a/constants/ChangedChatErrors.json
+++ b/constants/ChangedChatErrors.json
@@ -16,7 +16,8 @@
     },
     {
       "message_starts_with": [
-        "Error fetching data from NEU Lowest Bin API!"
+        "Error fetching data from NEU Lowest Bin API!",
+        "Asynchronous exception caught in bingo api fetch background"
       ],
       "fixed_in": "9.9.9"
     },


### PR DESCRIPTION
This error happens cause Hypixel API has blocked people.
So should just be silenced.

I am unsure if this is the correct message for this.
But should be, looking at reports.