### PR TITLE
fix Moonglade Marsh SC category bein' named wrong

### DIFF
--- a/constants/SeaCreatures.json
+++ b/constants/SeaCreatures.json
@@ -659,7 +659,7 @@
       }
     }
   },
-  "GALETEA": {
+  "MOONGLADE_MARSH": {
     "chat_color": "§2",
     "sea_creatures": {
       "Wetwing": {


### PR DESCRIPTION
not only does it spell "Galatea" wrong as "Galetea", but it wasn't caught in renamin' most instances of Galatea to Moonglade Marsh in line with the splittin' of Galatea into different island instances