### PR TITLE
Fix: JSON syntax error in ChangedChatErrors

### DIFF
--- a/constants/ChangedChatErrors.json
+++ b/constants/ChangedChatErrors.json
@@ -210,7 +210,7 @@
     },
     {
       "message_starts_with": [
-        "Could not read the rotating effect from chat",
+        "Could not read the rotating effect from chat"
       ],
       "fixed_in": "7.46.0"
     }


### PR DESCRIPTION
Workflow didn't catch this because it was a direct push by @hannibal002...