### PR TITLE
Silence current rotating perk lore line being missing

### DIFF
--- a/constants/ChangedChatErrors.json
+++ b/constants/ChangedChatErrors.json
@@ -210,7 +210,8 @@
     },
     {
       "message_starts_with": [
-        "Could not read the rotating effect from chat"
+        "Could not read the rotating effect from chat",
+        "Caused by java.lang.IllegalStateException: itemPreEffectPattern didn't match"
       ],
       "fixed_in": "7.46.0"
     }


### PR DESCRIPTION
<img width="689" height="494" alt="image" src="https://github.com/user-attachments/assets/6ce8ebdb-4265-4b56-9803-fda23dddd60e" />

When switching HOTM/HOTF layouts, the perk line does not appear.