### PR TITLE
Fix: Use an actual item for Vinyl Collector

### DIFF
--- a/constants/Garden.json
+++ b/constants/Garden.json
@@ -1378,7 +1378,7 @@
     "Vinyl Collector": {
       "rarity": "rare",
       "need_items": [
-        "Music Disc"
+        "Music Disc - 13"
       ],
       "mode": null,
       "position": null,


### PR DESCRIPTION
"Music Disc" is not an item in NEU repo, so it just shows as 🚫. Made it "Music Disc - 13" instead, chosen semi-arbitrarily based on being the lowest damage value music disc in 1.8.