### PR TITLE
Disable Boost Warning Volume for 7.52.0

### DIFF
--- a/constants/misc/EnforcedConfigValues.json
+++ b/constants/misc/EnforcedConfigValues.json
@@ -208,6 +208,17 @@
       "minimumAffectedVersion": "6.17.0",
       "affectedVersion": "7.99.0",
       "extraMessage": "Official wiki is dead"
+    },
+    {
+      "enforcedValues": [
+        {
+          "path": "misc.boostWarningVolume",
+          "value": false
+        }
+      ],
+      "minimumAffectedVersion": "7.52.0",
+      "affectedVersion": "7.52.0",
+      "extraMessage": "Will be re-enabled in 7.53.0"
     }
   ]
 }


### PR DESCRIPTION
A lot of people are complaining about this option being on by default, because it's way too loud and they're not used to it (while technically it was always "on by default", it was broken ever since 1.21.5). Worse, it also boosts the volume of *all* SkyHanni sounds to 100%, including UI clicks.

In this case, the option being permanently flipped off for existing users until they manually turn it back on is a feature, not a bug (it's already being done in https://github.com/hannibal002/SkyHanni/pull/6484 anyway).