### PR TITLE
Fix: Update Hoppity Time Tower slot ID

### DIFF
--- a/constants/HoppityEggLocations.json
+++ b/constants/HoppityEggLocations.json
@@ -18,7 +18,7 @@
   ],
   "noPickblockSlots": [
     13,
-    39
+    38
   ],
   "destructiveSlots": [
     47,


### PR DESCRIPTION
Time Tower moved from slot 39 to slot 38, so we need to adjust `noPickblockSlots`.