### PR TITLE
Fix: Remote disable moveable Action Bar & extend Boost Warning Volume version range

### DIFF
--- a/constants/misc/EnforcedConfigValues.json
+++ b/constants/misc/EnforcedConfigValues.json
@@ -217,8 +217,7 @@
         }
       ],
       "minimumAffectedVersion": "7.52.0",
-      "affectedVersion": "7.52.0",
-      "extraMessage": "Will be re-enabled in 7.53.0"
+      "affectedVersion": "9.0.0"
     }
   ]
 }

--- a/constants/misc/EnforcedConfigValues.json
+++ b/constants/misc/EnforcedConfigValues.json
@@ -218,6 +218,16 @@
       ],
       "minimumAffectedVersion": "7.52.0",
       "affectedVersion": "9.0.0"
+    },
+    {
+      "enforcedValues": [
+        {
+          "path": "gui.actionBar.enabled",
+          "value": false
+        }
+      ],
+      "affectedVersion": "7.53.0",
+      "extraMessage": "Will be re-enabled in 7.54.0"
     }
   ]
 }


### PR DESCRIPTION
- Remote disables the moveable Action Bar feature because of the GUI bug becoming widespread with the latest Skyblocker update. Probably a fairly niche feature and it's better to temporarily inconvenience a few people who wanted to move it than have the game be bugged for a lot of them. This is getting re-enabled in the next beta anyway. (https://github.com/hannibal002/SkyHanni/pull/6498)
- Extends Boost Warning Volume remote disable to 9.0.0 as a placeholder target for now until we decide on what should and shouldn't be a warning, can be lowered once that's done. Again, the few people who were missing this all along and never complained can wait a little, rather that than having people's ears blasted out. (https://github.com/hannibal002/SkyHanni/pull/6498)